### PR TITLE
Add exam selection page

### DIFF
--- a/exam-select.html
+++ b/exam-select.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Choose Exam</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="container">
+    <h1>Select Exam Type</h1>
+
+    <!-- Exam Selector -->
+    <div id="exam-selector">
+      <button data-exam="Midterm">Midterm</button>
+      <button data-exam="Final">Final</button>
+    </div>
+
+    <!-- Jeopardy Board -->
+    <div id="jeopardy-board" class="hidden"></div>
+
+    <!-- Question Modal -->
+    <div id="question-modal" class="hidden">
+      <div id="modal-content">
+        <p id="question-text"></p>
+        <input type="text" id="user-answer" placeholder="Type your answer here..." autocomplete="off">
+        <button id="submit-answer">Submit</button>
+        <div id="correct-answer" class="hidden"></div>
+        <button id="override-btn" class="hidden">Override as Correct</button>
+        <button id="close-modal" class="hidden">Continue</button>
+      </div>
+    </div>
+
+    <!-- Celebration Modal -->
+    <div id="celebration-modal" class="hidden">
+      <div class="celebration-content">
+        <h2>🎉 Congratulations! 🎉</h2>
+        <p>You've completed this Jeopardy session!</p>
+        <button id="restart-btn">Play Again</button>
+      </div>
+    </div>
+  </div>
+
+  <script src="data/ethics.js"></script>
+  <script src="data/critical-thinking.js"></script>
+  <script src="data/critical-thinking-midterm.js"></script>
+  <script src="data/intro-philosophy.js"></script>
+  <script src="script.js"></script>
+  <script src="exam-select.js"></script>
+</body>
+</html>

--- a/exam-select.js
+++ b/exam-select.js
@@ -1,0 +1,21 @@
+const topic = localStorage.getItem('selectedTopic');
+
+// If topic wasn't selected, redirect back to index
+if (!topic) {
+  window.location.href = 'index.html';
+}
+
+// Handle exam selection
+document.querySelectorAll('#exam-selector button').forEach(btn => {
+  btn.addEventListener('click', () => {
+    const exam = btn.dataset.exam;
+    localStorage.setItem('selectedExam', exam);
+
+    // hide selector and show board
+    document.getElementById('exam-selector').classList.add('hidden');
+    document.getElementById('jeopardy-board').classList.remove('hidden');
+
+    // load questions using topic and exam type
+    loadQuestions(topic, exam);
+  });
+});

--- a/index.html
+++ b/index.html
@@ -16,35 +16,8 @@
       <button data-topic="ethics">Ethics</button>
     </div>
 
-    <!-- Jeopardy Board -->
-    <div id="jeopardy-board"></div>
-
-    <!-- Question Modal -->
-    <div id="question-modal" class="hidden">
-      <div id="modal-content">
-        <p id="question-text"></p>
-        <input type="text" id="user-answer" placeholder="Type your answer here..." autocomplete="off">
-        <button id="submit-answer">Submit</button>
-        <div id="correct-answer" class="hidden"></div>
-        <button id="override-btn" class="hidden">Override as Correct</button>
-        <button id="close-modal" class="hidden">Continue</button>
-      </div>
-    </div>
-
-    <!-- Celebration Modal -->
-    <div id="celebration-modal" class="hidden">
-      <div class="celebration-content">
-        <h2>🎉 Congratulations! 🎉</h2>
-        <p>You've completed this Jeopardy session!</p>
-        <button id="restart-btn">Play Again</button>
-      </div>
-    </div>
   </div>
 
-  <script src="data/ethics.js"></script>
-  <script src="data/critical-thinking.js"></script>
-  <script src="data/critical-thinking-midterm.js"></script>
-  <script src="data/intro-philosophy.js"></script>
-  <script src="script.js"></script>
+  <script src="select-topic.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,15 +1,21 @@
 let currentQuestions = {};
 let remainingQuestions = 0;
 
-// Load selected topic questions
+// Previously the board could be built directly from topic buttons on
+// index.html. Topic selection now happens on a separate page so these
+// listeners are no longer required. The code remains defensive in case
+// the elements exist.
 document.querySelectorAll('#topic-selector button').forEach(btn => {
   btn.onclick = () => {
     loadQuestions(btn.dataset.topic);
   };
 });
 
-function loadQuestions(topic) {
-  currentQuestions = window[`${topic}Questions`];
+// Load questions for a topic and optional exam type. If the exam specific
+// question set does not exist, fall back to the generic set for that topic.
+function loadQuestions(topic, examType = '') {
+  const key = `${topic}${examType}Questions`;
+  currentQuestions = window[key] || window[`${topic}Questions`] || {};
   buildBoard();
 }
 

--- a/select-topic.js
+++ b/select-topic.js
@@ -1,0 +1,6 @@
+document.querySelectorAll('#topic-selector button').forEach(btn => {
+  btn.addEventListener('click', () => {
+    localStorage.setItem('selectedTopic', btn.dataset.topic);
+    window.location.href = 'exam-select.html';
+  });
+});


### PR DESCRIPTION
## Summary
- strip Jeopardy board from `index.html` so the page only lists topics
- add `exam-select.html` for choosing between Midterm and Final
- keep game logic in `script.js` but update `loadQuestions()` to accept exam types
- create helper scripts `select-topic.js` and `exam-select.js` to bridge between pages

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6857849a41d8832295fb2932bee0349b