### PR TITLE
Add fixed header with navigation buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,10 +6,8 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <div class="container">
-    <h1>Philosophy Review Jeopardy 🎓</h1>
-
-    <!-- Topic Selector with inline exam dropdowns -->
+  <nav id="top-nav">
+    <button id="home-btn">Home</button>
     <div id="topic-selector">
       <div class="course">
         <button class="topic-btn" data-topic="introPhilosophy">Intro to Philosophy</button>
@@ -33,6 +31,10 @@
         </div>
       </div>
     </div>
+  </nav>
+
+  <div class="container">
+    <h1>Philosophy Review Jeopardy 🎓</h1>
 
     <!-- Jeopardy Board and Modals -->
     <div id="jeopardy-board" class="hidden"></div>
@@ -57,6 +59,8 @@
     </div>
 
   </div>
+
+  <p class="copyright">&copy; Maxaeon 2025</p>
 
   <script src="data/ethics.js"></script>
   <script src="data/ethics-final.js"></script>

--- a/inline-select.js
+++ b/inline-select.js
@@ -22,3 +22,12 @@ document.querySelectorAll('#topic-selector .exam-dropdown button').forEach(examB
     loadQuestions(topic, examType);
   });
 });
+
+// Home button returns to topic selection
+
+document.getElementById('home-btn').addEventListener('click', () => {
+  document.getElementById('jeopardy-board').classList.add('hidden');
+  document.getElementById('topic-selector').classList.remove('hidden');
+  document.getElementById('question-modal').classList.add('hidden');
+  document.getElementById('celebration-modal').classList.add('hidden');
+});

--- a/style.css
+++ b/style.css
@@ -4,9 +4,37 @@ body {
   font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
 }
 
+#top-nav {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  background: #121212;
+  padding: 10px 0;
+  text-align: center;
+  z-index: 1000;
+}
+
+#top-nav button {
+  background-color: #9c27b0;
+  color: white;
+  border: none;
+  padding: 10px 16px;
+  margin: 0 8px;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 16px;
+  transition: transform 0.2s, background-color 0.3s;
+}
+
+#top-nav button:hover {
+  transform: translateY(-4px);
+  background-color: #7b1fa2;
+}
+
 .container {
   max-width: 1200px;
-  margin: 0 auto;
+  margin: 80px auto 0;
   padding: 20px;
   text-align: center;
 }
@@ -15,8 +43,8 @@ body {
   background-color: #9c27b0;
   color: white;
   border: none;
-  padding: 12px 20px;
-  margin: 10px;
+  padding: 10px 16px;
+  margin: 0 8px;
   border-radius: 8px;
   cursor: pointer;
   font-size: 16px;
@@ -96,3 +124,9 @@ button {
 #submit-answer { background: #8e24aa; color: white; }
 #override-btn { background: #b00020; color: white; }
 #close-modal, #restart-btn { background: #ba68c8; color: black; }
+
+.copyright {
+  margin: 40px 0;
+  text-align: center;
+  color: #ffffff;
+}


### PR DESCRIPTION
## Summary
- move topic selection buttons to a fixed navigation bar
- add a Home button to return to the topic selector
- ensure buttons remain visible at the top
- display copyright notice

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68578a45370c83228df26bb36409f704