### PR TITLE
Add scoreboard, game modes, and restructure board

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This repository contains a lightweight browser game that lets you review philoso
 - Multiple topics including Ethics, Critical Thinking, and Intro to Philosophy
 - Dynamic board built from question data files
 - Modal dialog for answering each question with the ability to override incorrect marking
+- Scoreboard with support for single player, multiplayer or a bot opponent
 
 ## Getting Started
 

--- a/index.html
+++ b/index.html
@@ -34,10 +34,11 @@
   </nav>
 
   <div class="container">
-    <h1>Philosophy Review Jeopardy 🎓</h1>
+    <h1>Philosophy Review Jeopardy</h1>
 
     <!-- Jeopardy Board and Modals -->
     <div id="jeopardy-board" class="hidden"></div>
+    <div id="scoreboard" class="hidden"></div>
 
     <div id="question-modal" class="hidden">
       <div id="modal-content">
@@ -52,7 +53,7 @@
 
     <div id="celebration-modal" class="hidden">
       <div class="celebration-content">
-        <h2>🎉 Congratulations! 🎉</h2>
+        <h2>Congratulations!</h2>
         <p>You've completed this Jeopardy session!</p>
         <button id="restart-btn">Play Again</button>
       </div>

--- a/inline-select.js
+++ b/inline-select.js
@@ -17,8 +17,11 @@ document.querySelectorAll('#topic-selector .exam-dropdown button').forEach(examB
   examBtn.addEventListener('click', () => {
     const examType = examBtn.dataset.exam;
     const topic = examBtn.closest('.course').querySelector('.topic-btn').dataset.topic;
+    const mode = prompt('Select mode: single, multi, bot', 'single');
+    startGame(mode);
     document.getElementById('topic-selector').classList.add('hidden');
     document.getElementById('jeopardy-board').classList.remove('hidden');
+    document.getElementById('scoreboard').classList.remove('hidden');
     loadQuestions(topic, examType);
   });
 });
@@ -30,4 +33,5 @@ document.getElementById('home-btn').addEventListener('click', () => {
   document.getElementById('topic-selector').classList.remove('hidden');
   document.getElementById('question-modal').classList.add('hidden');
   document.getElementById('celebration-modal').classList.add('hidden');
+  document.getElementById('scoreboard').classList.add('hidden');
 });

--- a/script.js
+++ b/script.js
@@ -1,5 +1,7 @@
 let currentQuestions = {};
 let remainingQuestions = 0;
+let players = [];
+let currentPlayerIndex = 0;
 
 // Topic buttons no longer load questions directly. Exam selection is handled
 // via inline dropdowns on the main page, but this remains here in case new
@@ -13,19 +15,66 @@ function loadQuestions(topic, examType = '') {
   buildBoard();
 }
 
+function startGame(mode) {
+  players = [];
+  if (mode === 'bot') {
+    players.push({ name: 'You', score: 0 });
+    players.push({ name: 'Bot', score: 0, isBot: true });
+  } else if (mode === 'multi') {
+    const count = parseInt(prompt('How many players? (2-4)')) || 2;
+    for (let i = 1; i <= count; i++) {
+      const name = prompt(`Name for Player ${i}`) || `Player ${i}`;
+      players.push({ name, score: 0 });
+    }
+  } else {
+    players.push({ name: 'Player 1', score: 0 });
+  }
+  currentPlayerIndex = 0;
+  document.getElementById('scoreboard').classList.remove('hidden');
+  updateScoreboard();
+}
+
+function updateScoreboard() {
+  const sb = document.getElementById('scoreboard');
+  sb.innerHTML = players
+    .map((p, idx) => `${idx === currentPlayerIndex ? '&#8594; ' : ''}${p.name}: ${p.score}`)
+    .join(' | ');
+}
+
+function nextPlayer() {
+  currentPlayerIndex = (currentPlayerIndex + 1) % players.length;
+  updateScoreboard();
+}
+
 function buildBoard() {
   const board = document.getElementById('jeopardy-board');
   board.innerHTML = '';
+  const categories = Object.keys(currentQuestions);
+  board.style.gridTemplateColumns = `repeat(${categories.length}, 1fr)`;
   remainingQuestions = 0;
 
-  Object.keys(currentQuestions).forEach(category => {
-    currentQuestions[category].forEach(q => {
+  // header row
+  categories.forEach(cat => {
+    const header = document.createElement('div');
+    header.className = 'jeopardy-header';
+    header.innerText = cat;
+    board.appendChild(header);
+  });
+
+  const pointLevels = [100, 200, 300, 400, 500];
+  pointLevels.forEach(value => {
+    categories.forEach(cat => {
+      const q = currentQuestions[cat].find(item => item.points === value);
       const cell = document.createElement('div');
       cell.className = 'jeopardy-cell';
-      cell.innerText = `${category}: ${q.points}`;
-      cell.onclick = () => showQuestion(q, cell);
+      cell.innerText = value;
+      if (q) {
+        cell.onclick = () => showQuestion(q, cell);
+        remainingQuestions++;
+      } else {
+        cell.classList.add('hidden');
+      }
       board.appendChild(cell);
-      remainingQuestions++;
     });
   });
 }
@@ -37,22 +86,55 @@ function showQuestion(questionObj, cell) {
   document.getElementById('question-text').innerText = questionObj.question;
   document.getElementById('user-answer').value = '';
   document.getElementById('correct-answer').innerText = `Correct Answer: ${questionObj.answer}`;
+  const userField = document.getElementById('user-answer');
+  const submitBtn = document.getElementById('submit-answer');
+  const overrideBtn = document.getElementById('override-btn');
+  const closeBtn = document.getElementById('close-modal');
 
-  document.getElementById('submit-answer').onclick = () => {
-    const userAns = document.getElementById('user-answer').value.trim().toLowerCase();
-    const correctAns = questionObj.answer.trim().toLowerCase();
+  userField.classList.add('hidden');
+  submitBtn.classList.add('hidden');
+  overrideBtn.classList.add('hidden');
+  closeBtn.classList.add('hidden');
+  document.getElementById('correct-answer').classList.add('hidden');
 
-    if (userAns === correctAns) {
-      closeQuestionModal();
+  const current = players[currentPlayerIndex];
+  if (current.isBot) {
+    const correct = Math.random() < 0.88;
+    if (correct) {
+      current.score += questionObj.points;
+      updateScoreboard();
+      setTimeout(closeQuestionModal, 800);
     } else {
       document.getElementById('correct-answer').classList.remove('hidden');
-      document.getElementById('override-btn').classList.remove('hidden');
-      document.getElementById('close-modal').classList.remove('hidden');
+      closeBtn.classList.remove('hidden');
     }
-  };
+  } else {
+    userField.classList.remove('hidden');
+    submitBtn.classList.remove('hidden');
 
-  document.getElementById('override-btn').onclick = closeQuestionModal;
-  document.getElementById('close-modal').onclick = closeQuestionModal;
+    submitBtn.onclick = () => {
+      const userAns = userField.value.trim().toLowerCase();
+      const correctAns = questionObj.answer.trim().toLowerCase();
+
+      if (userAns === correctAns) {
+        current.score += questionObj.points;
+        updateScoreboard();
+        closeQuestionModal();
+      } else {
+        document.getElementById('correct-answer').classList.remove('hidden');
+        overrideBtn.classList.remove('hidden');
+        closeBtn.classList.remove('hidden');
+      }
+    };
+
+    overrideBtn.onclick = () => {
+      current.score += questionObj.points;
+      updateScoreboard();
+      closeQuestionModal();
+    };
+  }
+
+  closeBtn.onclick = closeQuestionModal;
 }
 
 function closeQuestionModal() {
@@ -61,6 +143,7 @@ function closeQuestionModal() {
   document.getElementById('override-btn').classList.add('hidden');
   document.getElementById('close-modal').classList.add('hidden');
   remainingQuestions--;
+  nextPlayer();
 
   if (remainingQuestions === 0) {
     document.getElementById('celebration-modal').classList.remove('hidden');
@@ -69,5 +152,7 @@ function closeQuestionModal() {
 
 document.getElementById('restart-btn').onclick = () => {
   document.getElementById('celebration-modal').classList.add('hidden');
+  players.forEach(p => p.score = 0);
+  updateScoreboard();
   buildBoard();
 };

--- a/style.css
+++ b/style.css
@@ -63,6 +63,14 @@ body {
   margin-top: 20px;
 }
 
+.jeopardy-header {
+  background-color: #7b1fa2;
+  color: #fff;
+  padding: 20px;
+  border-radius: 6px;
+  font-weight: bold;
+}
+
 .jeopardy-cell {
   background-color: #ce93d8;
   color: #000;
@@ -129,4 +137,9 @@ button {
   margin: 40px 0;
   text-align: center;
   color: #ffffff;
+}
+
+#scoreboard {
+  margin-top: 20px;
+  font-size: 18px;
 }


### PR DESCRIPTION
## Summary
- remove emojis from gameplay and headings
- add scoreboard to track multiple players or bot
- reorganize board by point levels across categories
- allow selecting single player, multiplayer or bot opponent
- document new scoreboard feature

## Testing
- `grep -R -nP \p{Extended_Pictographic} .`

------
https://chatgpt.com/codex/tasks/task_e_68578bc7e56c8322a1bc68e3935c7f48