### PR TITLE
Enhance Jeopardy UI and gameplay flows

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,6 +35,7 @@
 
   <div class="container">
     <h1>Philosophy Review Jeopardy</h1>
+    <p id="instructions">Select a topic above to start a new game. Choose an exam type and game mode to challenge yourself or play with friends.</p>
 
     <!-- Jeopardy Board and Modals -->
     <div id="jeopardy-board" class="hidden"></div>
@@ -46,7 +47,12 @@
         <input type="text" id="user-answer" placeholder="Type your answer here..." autocomplete="off">
         <button id="submit-answer">Submit</button>
         <div id="correct-answer" class="hidden"></div>
+        <div id="bot-answer" class="hidden"></div>
         <button id="override-btn" class="hidden">Override as Correct</button>
+        <div id="bot-controls" class="hidden">
+          <button id="bot-yes">Give Points</button>
+          <button id="bot-no">No Points</button>
+        </div>
         <button id="close-modal" class="hidden">Continue</button>
       </div>
     </div>
@@ -59,9 +65,36 @@
       </div>
     </div>
 
+    <div id="mode-modal" class="hidden">
+      <div class="modal-content">
+        <h2>Select Game Mode</h2>
+        <button id="single-mode">Single Player</button>
+        <button id="multi-mode">Multiplayer</button>
+        <button id="bot-mode">Vs Bot</button>
+      </div>
+    </div>
+
+    <div id="multi-modal" class="hidden">
+      <div class="modal-content">
+        <h2>Multiplayer Setup</h2>
+        <label for="player-count">Number of Players (2-4)</label>
+        <input id="player-count" type="number" min="2" max="4" value="2">
+        <div id="name-fields"></div>
+        <button id="start-multi">Start Game</button>
+      </div>
+    </div>
+
+    <div id="quit-modal" class="hidden">
+      <div class="modal-content">
+        <p>Are you sure you want to quit the current game?</p>
+        <button id="quit-yes">Yes</button>
+        <button id="quit-no">No</button>
+      </div>
+    </div>
+
   </div>
 
-  <p class="copyright">&copy; Maxaeon 2025</p>
+  <footer class="site-footer">&copy; Maxaeon 2025</footer>
 
   <script src="data/ethics.js"></script>
   <script src="data/ethics-final.js"></script>

--- a/inline-select.js
+++ b/inline-select.js
@@ -13,25 +13,89 @@ document.querySelectorAll('#topic-selector .topic-btn').forEach(topicBtn => {
 
 // When an exam button is clicked, load questions and reveal the board
 
+let selectedTopic = '';
+let selectedExam = '';
+
+const modeModal = document.getElementById('mode-modal');
+const multiModal = document.getElementById('multi-modal');
+const playerCount = document.getElementById('player-count');
+const nameFields = document.getElementById('name-fields');
+
+function showModeModal(topic, exam) {
+  selectedTopic = topic;
+  selectedExam = exam;
+  modeModal.classList.remove('hidden');
+}
+
+function startSelectedGame(mode, names = []) {
+  modeModal.classList.add('hidden');
+  multiModal.classList.add('hidden');
+  startGame(mode, names);
+  document.getElementById('topic-selector').classList.add('hidden');
+  document.getElementById('jeopardy-board').classList.remove('hidden');
+  document.getElementById('scoreboard').classList.remove('hidden');
+  loadQuestions(selectedTopic, selectedExam);
+}
+
+function updateNameFields() {
+  const count = Math.min(Math.max(parseInt(playerCount.value) || 2, 2), 4);
+  nameFields.innerHTML = '';
+  for (let i = 1; i <= count; i++) {
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.placeholder = `Player ${i} name`;
+    nameFields.appendChild(input);
+  }
+}
+
+playerCount.addEventListener('input', updateNameFields);
+updateNameFields();
+
+document.getElementById('single-mode').onclick = () => startSelectedGame('single');
+document.getElementById('bot-mode').onclick = () => startSelectedGame('bot');
+document.getElementById('multi-mode').onclick = () => {
+  modeModal.classList.add('hidden');
+  multiModal.classList.remove('hidden');
+};
+
+document.getElementById('start-multi').onclick = () => {
+  const names = Array.from(nameFields.querySelectorAll('input')).map((i, idx) => i.value || `Player ${idx+1}`);
+  startSelectedGame('multi', names);
+};
+
 document.querySelectorAll('#topic-selector .exam-dropdown button').forEach(examBtn => {
   examBtn.addEventListener('click', () => {
     const examType = examBtn.dataset.exam;
     const topic = examBtn.closest('.course').querySelector('.topic-btn').dataset.topic;
-    const mode = prompt('Select mode: single, multi, bot', 'single');
-    startGame(mode);
-    document.getElementById('topic-selector').classList.add('hidden');
-    document.getElementById('jeopardy-board').classList.remove('hidden');
-    document.getElementById('scoreboard').classList.remove('hidden');
-    loadQuestions(topic, examType);
+    showModeModal(topic, examType);
   });
 });
 
 // Home button returns to topic selection
 
-document.getElementById('home-btn').addEventListener('click', () => {
+const quitModal = document.getElementById('quit-modal');
+
+function goHome() {
   document.getElementById('jeopardy-board').classList.add('hidden');
   document.getElementById('topic-selector').classList.remove('hidden');
   document.getElementById('question-modal').classList.add('hidden');
   document.getElementById('celebration-modal').classList.add('hidden');
   document.getElementById('scoreboard').classList.add('hidden');
+}
+
+document.getElementById('home-btn').addEventListener('click', () => {
+  if (!document.getElementById('jeopardy-board').classList.contains('hidden')) {
+    quitModal.classList.remove('hidden');
+  } else {
+    goHome();
+  }
 });
+
+document.getElementById('quit-yes').onclick = () => {
+  quitModal.classList.add('hidden');
+  goHome();
+};
+
+document.getElementById('quit-no').onclick = () => {
+  quitModal.classList.add('hidden');
+};

--- a/script.js
+++ b/script.js
@@ -15,15 +15,15 @@ function loadQuestions(topic, examType = '') {
   buildBoard();
 }
 
-function startGame(mode) {
+function startGame(mode, names = []) {
   players = [];
   if (mode === 'bot') {
     players.push({ name: 'You', score: 0 });
     players.push({ name: 'Bot', score: 0, isBot: true });
   } else if (mode === 'multi') {
-    const count = parseInt(prompt('How many players? (2-4)')) || 2;
-    for (let i = 1; i <= count; i++) {
-      const name = prompt(`Name for Player ${i}`) || `Player ${i}`;
+    const count = Math.min(Math.max(names.length || 2, 2), 4);
+    for (let i = 0; i < count; i++) {
+      const name = names[i] || `Player ${i + 1}`;
       players.push({ name, score: 0 });
     }
   } else {
@@ -90,24 +90,39 @@ function showQuestion(questionObj, cell) {
   const submitBtn = document.getElementById('submit-answer');
   const overrideBtn = document.getElementById('override-btn');
   const closeBtn = document.getElementById('close-modal');
+  const botAnswerEl = document.getElementById('bot-answer');
+  const botControls = document.getElementById('bot-controls');
+  const botYes = document.getElementById('bot-yes');
+  const botNo = document.getElementById('bot-no');
 
   userField.classList.add('hidden');
   submitBtn.classList.add('hidden');
   overrideBtn.classList.add('hidden');
   closeBtn.classList.add('hidden');
+  botAnswerEl.classList.add('hidden');
+  botControls.classList.add('hidden');
   document.getElementById('correct-answer').classList.add('hidden');
 
   const current = players[currentPlayerIndex];
   if (current.isBot) {
     const correct = Math.random() < 0.88;
-    if (correct) {
-      current.score += questionObj.points;
-      updateScoreboard();
-      setTimeout(closeQuestionModal, 800);
-    } else {
-      document.getElementById('correct-answer').classList.remove('hidden');
-      closeBtn.classList.remove('hidden');
-    }
+    const botAns = correct ? questionObj.answer : '???';
+    botAnswerEl.innerText = `Bot answers: ${botAns}`;
+    botAnswerEl.classList.remove('hidden');
+    document.getElementById('correct-answer').classList.remove('hidden');
+    botControls.classList.remove('hidden');
+
+    botYes.onclick = () => {
+      if (correct) {
+        current.score += questionObj.points;
+        updateScoreboard();
+      }
+      closeQuestionModal();
+    };
+
+    botNo.onclick = () => {
+      closeQuestionModal();
+    };
   } else {
     userField.classList.remove('hidden');
     submitBtn.classList.remove('hidden');
@@ -142,6 +157,8 @@ function closeQuestionModal() {
   document.getElementById('correct-answer').classList.add('hidden');
   document.getElementById('override-btn').classList.add('hidden');
   document.getElementById('close-modal').classList.add('hidden');
+  document.getElementById('bot-answer').classList.add('hidden');
+  document.getElementById('bot-controls').classList.add('hidden');
   remainingQuestions--;
   nextPlayer();
 

--- a/style.css
+++ b/style.css
@@ -2,6 +2,7 @@ body {
   background-color: #121212;
   color: #ffffff;
   font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  line-height: 1.6;
 }
 
 #top-nav {
@@ -11,7 +12,9 @@ body {
   width: 100%;
   background: #121212;
   padding: 10px 0;
-  text-align: center;
+  display: flex;
+  justify-content: center;
+  gap: 12px;
   z-index: 1000;
 }
 
@@ -39,6 +42,12 @@ body {
   text-align: center;
 }
 
+#instructions {
+  margin-bottom: 20px;
+  font-size: 18px;
+  color: #e0e0e0;
+}
+
 #topic-selector button {
   background-color: #9c27b0;
   color: white;
@@ -49,6 +58,25 @@ body {
   cursor: pointer;
   font-size: 16px;
   transition: transform 0.2s, background-color 0.3s;
+}
+
+.course {
+  position: relative;
+  display: inline-block;
+}
+
+.exam-dropdown {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-top: 4px;
+}
+
+.exam-dropdown button {
+  background-color: #d1c4e9;
+  color: #000;
+  font-size: 14px;
+  margin-top: 4px;
 }
 
 #topic-selector button:hover {
@@ -88,7 +116,7 @@ body {
   display: none;
 }
 
-#question-modal, #celebration-modal {
+#question-modal, #celebration-modal, #mode-modal, #multi-modal, #quit-modal {
   position: fixed;
   inset: 0;
   background: rgba(0, 0, 0, 0.85);
@@ -98,7 +126,10 @@ body {
 }
 
 #question-modal.hidden,
-#celebration-modal.hidden {
+#celebration-modal.hidden,
+#mode-modal.hidden,
+#multi-modal.hidden,
+#quit-modal.hidden {
   display: none;
 }
 
@@ -120,6 +151,10 @@ input {
   font-size: 16px;
 }
 
+#name-fields input {
+  margin-top: 6px;
+}
+
 button {
   margin-top: 15px;
   padding: 10px 20px;
@@ -129,14 +164,26 @@ button {
   font-weight: bold;
 }
 
+#bot-controls {
+  display: flex;
+  justify-content: center;
+  gap: 10px;
+  margin-top: 10px;
+}
+
+#bot-controls button {
+  margin-top: 0;
+}
+
 #submit-answer { background: #8e24aa; color: white; }
 #override-btn { background: #b00020; color: white; }
 #close-modal, #restart-btn { background: #ba68c8; color: black; }
 
-.copyright {
-  margin: 40px 0;
+.site-footer {
+  margin: 40px 0 10px 0;
   text-align: center;
   color: #ffffff;
+  width: 100%;
 }
 
 #scoreboard {


### PR DESCRIPTION
## Summary
- add instructions and multiple new modals to `index.html`
- center navigation and footer styles
- style exam dropdown buttons and bot controls
- implement modal-based mode selection and quit confirmation
- show bot answers until points decision

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68578e8ac3c8832286a48fe48b9e953f