### PR TITLE
Add manual score override and improved menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,7 +86,7 @@
 
     <div id="quit-modal" class="hidden">
       <div class="modal-content">
-        <p>Are you sure you want to quit the current game?</p>
+        <p>Are you sure you want to leave? Your progress will not be saved.</p>
         <button id="quit-yes">Yes</button>
         <button id="quit-no">No</button>
       </div>

--- a/inline-select.js
+++ b/inline-select.js
@@ -81,6 +81,7 @@ function goHome() {
   document.getElementById('question-modal').classList.add('hidden');
   document.getElementById('celebration-modal').classList.add('hidden');
   document.getElementById('scoreboard').classList.add('hidden');
+  document.getElementById('instructions').scrollIntoView();
 }
 
 document.getElementById('home-btn').addEventListener('click', () => {

--- a/script.js
+++ b/script.js
@@ -2,6 +2,7 @@ let currentQuestions = {};
 let remainingQuestions = 0;
 let players = [];
 let currentPlayerIndex = 0;
+let maxPossibleScore = 0;
 
 // Topic buttons no longer load questions directly. Exam selection is handled
 // via inline dropdowns on the main page, but this remains here in case new
@@ -37,7 +38,10 @@ function startGame(mode, names = []) {
 function updateScoreboard() {
   const sb = document.getElementById('scoreboard');
   sb.innerHTML = players
-    .map((p, idx) => `${idx === currentPlayerIndex ? '&#8594; ' : ''}${p.name}: ${p.score}`)
+    .map((p, idx) => {
+      const prefix = idx === currentPlayerIndex ? '&#8594; ' : '';
+      return `<span class="player-score" data-index="${idx}">${prefix}${p.name}: ${p.score}</span>`;
+    })
     .join(' | ');
 }
 
@@ -52,6 +56,7 @@ function buildBoard() {
   const categories = Object.keys(currentQuestions);
   board.style.gridTemplateColumns = `repeat(${categories.length}, 1fr)`;
   remainingQuestions = 0;
+  maxPossibleScore = 0;
 
   // header row
   categories.forEach(cat => {
@@ -71,6 +76,7 @@ function buildBoard() {
       if (q) {
         cell.onclick = () => showQuestion(q, cell);
         remainingQuestions++;
+        maxPossibleScore += q.points;
       } else {
         cell.classList.add('hidden');
       }
@@ -173,3 +179,23 @@ document.getElementById('restart-btn').onclick = () => {
   updateScoreboard();
   buildBoard();
 };
+
+// Allow manual score overrides via scoreboard clicks
+document.getElementById('scoreboard').addEventListener('click', (e) => {
+  if (!e.target.classList.contains('player-score')) return;
+  const idx = parseInt(e.target.dataset.index, 10);
+  const current = players[idx];
+  const input = prompt(`Set score for ${current.name} (0-${maxPossibleScore})`, current.score);
+  if (input === null) return;
+  if (!/^\d+$/.test(input)) {
+    alert('Please enter a valid number.');
+    return;
+  }
+  const value = parseInt(input, 10);
+  if (value > maxPossibleScore) {
+    alert(`Score cannot exceed ${maxPossibleScore}.`);
+    return;
+  }
+  current.score = value;
+  updateScoreboard();
+});

--- a/style.css
+++ b/style.css
@@ -66,14 +66,22 @@ body {
 }
 
 .exam-dropdown {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
   display: flex;
   flex-direction: column;
   align-items: center;
+  background-color: #d1c4e9;
+  padding: 4px 0;
+  border-radius: 8px;
   margin-top: 4px;
+  z-index: 500;
 }
 
 .exam-dropdown button {
-  background-color: #d1c4e9;
+  background-color: transparent;
   color: #000;
   font-size: 14px;
   margin-top: 4px;
@@ -189,4 +197,8 @@ button {
 #scoreboard {
   margin-top: 20px;
   font-size: 18px;
+}
+
+.player-score {
+  cursor: pointer;
 }


### PR DESCRIPTION
## Summary
- allow editing scores directly from the scoreboard with validation
- style exam dropdown with a light purple background and absolute position
- confirm leaving the current game via updated home modal
- scroll to instructions when returning home

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685790d4476083228feaf5bf73612c70