### PR TITLE
Restructure intro philosophy set

### DIFF
--- a/data/intro-philosophy.js
+++ b/data/intro-philosophy.js
@@ -1,5 +1,5 @@
 window.introPhilosophyQuestions = {
-  "Chapter 1": [
+  "Introduction to Philosophy": [
     { question: "What distinguishes philosophy from other disciplines?", answer: "It uses critical evaluation, reflection, and systematic argument to pursue fundamental questions.", points: 100 },
     { question: "What are the two main tools of philosophy?", answer: "Argument and logic.", points: 200 },
     { question: "Identify three divisions of philosophy.", answer: "Metaphysics, epistemology, ethics.", points: 300 },
@@ -7,31 +7,15 @@ window.introPhilosophyQuestions = {
     { question: "Define a normative question.", answer: "It asks how one ought to act or what should be valued.", points: 500 }
   ],
 
-  "Chapter 2": [
+  "Ancient Greek Philosophy": [
     { question: "What fundamental question does metaphysics ask?", answer: "What is the nature of being?", points: 100 },
-    { question: "Who were the Milesians and what did they seek?", answer: "Early Greek philosophers seeking underlying substance.", points: 200 },
-    { question: "Summarize Heraclitus's view of reality.", answer: "Reality is in constant flux; stability is an illusion.", points: 300 },
-    { question: "What did Parmenides claim about being?", answer: "Being is one, unchanging, and indivisible.", points: 400 },
-    { question: "What is the 'logos' according to Heraclitus?", answer: "The rational order governing change.", points: 500 }
-  ],
-
-  "Chapter 3": [
-    { question: "What is Socratic questioning?", answer: "Dialectical method of probing definitions and seeking clarity.", points: 100 },
     { question: "Define the Allegory of the Cave.", answer: "A metaphor for moving from appearance to reality.", points: 200 },
-    { question: "What is Plato's theory of Forms?", answer: "Abstract perfect templates for material things.", points: 300 },
+    { question: "Name Aristotle's four causes.", answer: "Material, formal, efficient, final.", points: 300 },
     { question: "Why does Socrates value an examined life?", answer: "Self-examination leads to meaningful living.", points: 400 },
     { question: "What does Plato’s Republic suggest about justice?", answer: "Each soul/class doing its proper role.", points: 500 }
   ],
 
-  "Chapter 4": [
-    { question: "How does Aristotle define substance?", answer: "Combination of form and matter.", points: 100 },
-    { question: "Difference between actuality and potentiality?", answer: "Actuality is realized; potentiality is capacity.", points: 200 },
-    { question: "Name Aristotle's four causes.", answer: "Material, formal, efficient, final.", points: 300 },
-    { question: "Summarize Aristotle's doctrine of the Mean.", answer: "Virtue is balanced midpoint between extremes.", points: 400 },
-    { question: "Primary vs secondary qualities?", answer: "Primary objective; secondary perceptual.", points: 500 }
-  ],
-
-  "Chapter 5": [
+  "Hellenistic & Medieval": [
     { question: "Name two Hellenistic schools and their focus.", answer: "Stoicism and Epicureanism.", points: 100 },
     { question: "Augustine’s blend of philosophy and faith?", answer: "Argued for divine illumination and grace.", points: 200 },
     { question: "Aquinas on faith and reason?", answer: "They are harmonious; reason supports faith.", points: 300 },
@@ -39,7 +23,7 @@ window.introPhilosophyQuestions = {
     { question: "Epicurean core principle?", answer: "Ataraxia, peace, absence of disturbance.", points: 500 }
   ],
 
-  "Chapter 6": [
+  "Rationalism & Empiricism": [
     { question: "Descartes's methodological doubt?", answer: "Reject beliefs doubtable to find certainty.", points: 100 },
     { question: "Meaning of 'cogito ergo sum'?", answer: "I think therefore I am.", points: 200 },
     { question: "Clear and distinct perception?", answer: "Criterion for truth; clearly perceived is true.", points: 300 },
@@ -47,7 +31,7 @@ window.introPhilosophyQuestions = {
     { question: "Berkeley’s 'to be is to be perceived'?", answer: "Only ideas and perceivers exist, not matter.", points: 500 }
   ],
 
-  "Chapter 7": [
+  "Hume & Kant": [
     { question: "Hume’s fork divides knowledge into?", answer: "Relations of ideas vs. matters of fact.", points: 100 },
     { question: "Hume's problem of induction?", answer: "Past experience can't guarantee future outcomes.", points: 200 },
     { question: "Hume’s association of ideas?", answer: "Thoughts connect by resemblance, contiguity, causation.", points: 300 },
@@ -55,7 +39,7 @@ window.introPhilosophyQuestions = {
     { question: "Kant’s epistemological revolution?", answer: "Bridged rationalism and empiricism.", points: 500 }
   ],
 
-  "Chapter 8": [
+  "Phenomenology & Existentialism": [
     { question: "Phenomenology defined?", answer: "Study of structures of consciousness.", points: 100 },
     { question: "Heidegger’s critique of Cartesian thought?", answer: "Dasein foundational over detached thinking.", points: 200 },
     { question: "Existentialism in Sartre’s terms?", answer: "Existence precedes essence.", points: 300 },
@@ -63,7 +47,7 @@ window.introPhilosophyQuestions = {
     { question: "Language in Heidegger’s view?", answer: "Language discloses being.", points: 500 }
   ],
 
-  "Chapter 9": [
+  "Pragmatism & Analytic Philosophy": [
     { question: "What is pragmatism?", answer: "Meaning based on practical consequences.", points: 100 },
     { question: "Analytic philosophy’s method?", answer: "Logical analysis of language/concepts.", points: 200 },
     { question: "Wittgenstein’s critique?", answer: "Meaning is use within language-games.", points: 300 },


### PR DESCRIPTION
## Summary
- merge early Greek philosophy chapters into a single category
- rename remaining categories with descriptive titles
- keep five questions per category

## Testing
- `node - <<'NODE'
global.window={};
require('./data/intro-philosophy.js');
console.log(Object.fromEntries(Object.entries(window.introPhilosophyQuestions).map(([k,v])=>[k,v.length])));
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68585e5705b08322a78dc283e39034c1