### PR TITLE
Add player name input and rename categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This repository contains a lightweight browser game that lets you review philoso
 - Dynamic board built from question data files
 - Modal dialog for answering each question
 - Scoreboard with support for single player or multiplayer teams
+- Single-player mode lets you enter your name, displayed next to your score
 
 ## Getting Started
 

--- a/data/critical-thinking-final.js
+++ b/data/critical-thinking-final.js
@@ -1,6 +1,6 @@
 // Final exam questions for the Critical Thinking course
 window.criticalThinkingFinalQuestions = {
-  "Chapter 8: Evaluating Arguments & Truth Claims": [
+  "Evaluating Arguments & Truth Claims": [
     {
       question: "When is it reasonable to accept a premise as true?",
       answer: "When it is backed by credible evidence, expert consensus, common knowledge, or reliable experience.",
@@ -28,7 +28,7 @@ window.criticalThinkingFinalQuestions = {
     }
   ],
 
-  "Chapter 9: Causal Arguments": [
+  "Causal Arguments": [
     { question: "What principle says simpler explanations are usually better?", answer: "Occam's Razor.", points: 100 },
     { question: "Define the post hoc fallacy.", answer: "Assuming that because one event follows another, the first caused the second.", points: 200 },
     { question: "What is the difference between correlation and causation?", answer: "Correlation is when events occur together; causation is when one event produces another.", points: 300 },
@@ -36,7 +36,7 @@ window.criticalThinkingFinalQuestions = {
     { question: "What is a sufficient condition?", answer: "A condition that guarantees an event will occur.", points: 500 }
   ],
 
-  "Chapter 10: Inference to the Best Explanation": [
+  "Inference to the Best Explanation": [
     { question: "What is inference to the best explanation?", answer: "Choosing the hypothesis that best explains the evidence.", points: 100 },
     { question: "Define explanatory power.", answer: "The extent to which a hypothesis explains the relevant evidence.", points: 200 },
     { question: "What quality of a hypothesis refers to fitting well with existing knowledge?", answer: "Conservatism.", points: 300 },
@@ -44,7 +44,7 @@ window.criticalThinkingFinalQuestions = {
     { question: "What does simplicity in a hypothesis mean?", answer: "Making fewer assumptions or being less complicated.", points: 500 }
   ],
 
-  "Chapter 11: Judging Scientific Theories": [
+  "Judging Scientific Theories": [
     { question: "What makes a scientific theory fruitful?", answer: "It successfully predicts new phenomena and opens new research lines.", points: 100 },
     { question: "What does it mean for a theory to be falsifiable?", answer: "It can be shown wrong through observation or experiment.", points: 200 },
     { question: "What distinguishes science from pseudoscience?", answer: "Science is testable and falsifiable, whereas pseudoscience typically is not.", points: 300 },
@@ -52,7 +52,7 @@ window.criticalThinkingFinalQuestions = {
     { question: "What does consistency mean for a scientific theory?", answer: "The theory does not contradict itself or established facts.", points: 500 }
   ],
 
-  "Chapter 12: Moral Arguments": [
+  "Moral Arguments": [
     { question: "What is a moral statement?", answer: "A claim asserting that an action is right or wrong or something is good or bad.", points: 100 },
     { question: "Define moral relativism.", answer: "The view that moral standards depend on cultural or individual preferences.", points: 200 },
     { question: "What is the is–ought fallacy?", answer: "Drawing moral conclusions solely from factual premises.", points: 300 },
@@ -60,7 +60,7 @@ window.criticalThinkingFinalQuestions = {
     { question: "What characterizes a deontological ethical theory?", answer: "It evaluates actions based on rules and duties rather than outcomes.", points: 500 }
   ],
 
-  "Chapter 13: Legal Reasoning": [
+  "Legal Reasoning": [
     { question: "What does the term 'precedent' mean in law?", answer: "A legal decision that guides future rulings on similar cases.", points: 100 },
     { question: "What is statutory interpretation?", answer: "Determining the meaning of laws enacted by legislatures.", points: 200 },
     { question: "What principle is expressed by stare decisis?", answer: "Courts should follow established precedents.", points: 300 },

--- a/data/critical-thinking-midterm.js
+++ b/data/critical-thinking-midterm.js
@@ -1,5 +1,5 @@
 window.criticalThinkingMidtermQuestions = {
-  "Chapter 1 - Introduction": [
+  "Introduction": [
     { question: "What is critical thinking?", answer: "The systematic evaluation or formulation of beliefs or statements by rational standards.", points: 100 },
     { question: "Name one obstacle to effective critical thinking.", answer: "Egocentrism, confirmation bias, or sociocentrism.", points: 200 },
     { question: "Give one reason why critical thinking is important in everyday life.", answer: "Helps make better decisions, understand complex issues, or avoid manipulation.", points: 300 },
@@ -7,7 +7,7 @@ window.criticalThinkingMidtermQuestions = {
     { question: "What is group bias (or sociocentrism)?", answer: "Uncritically accepting views or opinions of one's own group.", points: 500 }
   ],
 
-  "Chapter 2 - Recognizing Arguments": [
+  "Recognizing Arguments": [
     { question: "Define 'argument' in critical thinking.", answer: "A set of statements where premises support a conclusion.", points: 100 },
     { question: "What is a premise?", answer: "A statement intended to support a conclusion.", points: 200 },
     { question: "True or False: An assertion by itself is an argument.", answer: "False.", points: 300 },
@@ -15,7 +15,7 @@ window.criticalThinkingMidtermQuestions = {
     { question: "What is a premise indicator word? Give an example.", answer: "Words signaling a premise, e.g., 'because', 'since', 'given that'.", points: 500 }
   ],
 
-  "Chapter 3 - Basic Logical Concepts": [
+  "Basic Logical Concepts": [
     { question: "What does it mean for an argument to be valid?", answer: "If the premises are true, the conclusion must be true.", points: 100 },
     { question: "What is soundness?", answer: "An argument that is valid and has all true premises.", points: 200 },
     { question: "True or False: An argument can be valid even if all premises are false.", answer: "True.", points: 300 },
@@ -23,7 +23,7 @@ window.criticalThinkingMidtermQuestions = {
     { question: "Can a sound argument have a false conclusion?", answer: "No, a sound argument must have a true conclusion.", points: 500 }
   ],
 
-  "Chapter 4 - Language": [
+  "Language": [
     { question: "What is ambiguity?", answer: "Having multiple distinct meanings.", points: 100 },
     { question: "Define vagueness.", answer: "Lack of clear boundaries or precision in meaning.", points: 200 },
     { question: "What is a euphemism?", answer: "A mild term substituted for one considered harsh.", points: 300 },
@@ -31,7 +31,7 @@ window.criticalThinkingMidtermQuestions = {
     { question: "Explain the fallacy of equivocation.", answer: "Using a word in two different senses within an argument.", points: 500 }
   ],
 
-  "Chapter 5 - Logical Fallacies I": [
+  "Logical Fallacies I": [
     { question: "Describe the ad hominem fallacy.", answer: "Attacking the person rather than addressing their argument.", points: 100 },
     { question: "What is a straw man fallacy?", answer: "Misrepresenting an argument to easily attack it.", points: 200 },
     { question: "Define appeal to tradition fallacy.", answer: "Arguing something is true because it's traditional or longstanding.", points: 300 },
@@ -39,7 +39,7 @@ window.criticalThinkingMidtermQuestions = {
     { question: "Describe the genetic fallacy.", answer: "Judging a claim true or false based on its origin or source.", points: 500 }
   ],
 
-  "Chapter 6 - Logical Fallacies II": [
+  "Logical Fallacies II": [
     { question: "Explain the slippery slope fallacy.", answer: "Arguing without evidence that a small step inevitably leads to a severe outcome.", points: 100 },
     { question: "What is a false dilemma?", answer: "Presenting only two options when more exist.", points: 200 },
     { question: "Define begging the question.", answer: "Using a conclusion as a premise (circular reasoning).", points: 300 },
@@ -47,7 +47,7 @@ window.criticalThinkingMidtermQuestions = {
     { question: "Explain appeal to ignorance.", answer: "Arguing a claim is true because it hasn't been proven false, or vice versa.", points: 500 }
   ],
 
-  "Chapter 7 - Analyzing Arguments": [
+  "Analyzing Arguments": [
     { question: "Define a deductive argument.", answer: "Argument where conclusion necessarily follows from premises.", points: 100 },
     { question: "Define an inductive argument.", answer: "Argument where conclusion is likely but not guaranteed by premises.", points: 200 },
     { question: "True or False: Inductive arguments can be valid.", answer: "False. Validity applies only to deductive arguments.", points: 300 },

--- a/data/ethics.js
+++ b/data/ethics.js
@@ -1,5 +1,5 @@
 window.ethicsQuestions = {
-  "Chapter 1: Ethics & Moral Reasoning": [
+  "Ethics & Moral Reasoning": [
     {
       question: "What is normative ethics?",
       answer: "The study of principles, rules, or theories guiding our actions and judgments.",
@@ -26,7 +26,7 @@ window.ethicsQuestions = {
       points: 500
     }
   ],
-  "Chapter 2: Subjectivism, Relativism, and Emotivism": [
+  "Subjectivism, Relativism, and Emotivism": [
     {
       question: "What does cultural relativism claim?",
       answer: "Morality is relative to specific cultures; no universal moral standards exist.",
@@ -53,7 +53,7 @@ window.ethicsQuestions = {
       points: 500
     }
   ],
-  "Chapter 3: Evaluating Moral Arguments": [
+  "Evaluating Moral Arguments": [
     {
       question: "What is a moral argument?",
       answer: "An argument that contains at least one moral premise and one non-moral premise.",
@@ -80,7 +80,7 @@ window.ethicsQuestions = {
       points: 500
     }
   ],
-  "Chapter 4: Moral Theories": [
+  "Moral Theories": [
     {
       question: "What is consequentialism?",
       answer: "The view that morality is based solely on the consequences of actions.",
@@ -107,7 +107,7 @@ window.ethicsQuestions = {
       points: 500
     }
   ],
-  "Chapter 5: Consequentialist Theories (Utilitarianism)": [
+  "Consequentialist Theories (Utilitarianism)": [
     {
       question: "Define utilitarianism.",
       answer: "The ethical theory stating the right action maximizes overall happiness or utility.",

--- a/data/intro-philosophy-final.js
+++ b/data/intro-philosophy-final.js
@@ -1,6 +1,6 @@
 // Final exam questions for Intro to Philosophy
 window.introPhilosophyFinalQuestions = {
-  "Chapter 10": [
+  "Analytic Philosophy": [
     { question: "Who is known as the founder of the analytic tradition?", answer: "Gottlob Frege or Bertrand Russell.", points: 100 },
     { question: "What is Charles Sanders Peirce\u2019s pragmatic maxim?", answer: "The meaning of a concept lies in its practical consequences.", points: 200 },
     { question: "Which philosopher introduced the verification principle?", answer: "A.J. Ayer.", points: 300 },
@@ -22,7 +22,7 @@ window.introPhilosophyFinalQuestions = {
     { question: "What is the core idea behind social contract theory?", answer: "People give up freedom for protection and order.", points: 500 }
   ],
 
-  "Chapter 14": [
+  "Philosophy of Religion": [
     { question: "What does the cosmological argument aim to prove?", answer: "God as the first cause or prime mover.", points: 100 },
     { question: "What problem does evil pose for theism?", answer: "Challenges an all-good, all-powerful God.", points: 200 },
     { question: "What is Pascal\u2019s Wager?", answer: "It's rational to believe in God given potential infinite gain.", points: 300 },
@@ -30,7 +30,7 @@ window.introPhilosophyFinalQuestions = {
     { question: "Which argument infers God\u2019s existence from design?", answer: "Teleological argument.", points: 500 }
   ],
 
-  "Chapter 15": [
+  "Feminist Philosophy": [
     { question: "What critique do feminist philosophers have of traditional philosophy?", answer: "Exclusion of women's perspectives.", points: 100 },
     { question: "What is the ethics of care?", answer: "Emphasizes care and relationships.", points: 200 },
     { question: "What does standpoint theory claim?", answer: "Knowledge is shaped by social positions.", points: 300 },

--- a/index.html
+++ b/index.html
@@ -67,6 +67,7 @@
     <div id="mode-modal" class="hidden">
       <div class="modal-content">
         <h2>Select Game Mode</h2>
+        <input id="single-name" type="text" placeholder="Your name">
         <button id="single-mode">Single Player</button>
         <button id="multi-mode">Multiplayer</button>
       </div>

--- a/inline-select.js
+++ b/inline-select.js
@@ -17,6 +17,7 @@ let selectedTopic = '';
 let selectedExam = '';
 
 const modeModal = document.getElementById('mode-modal');
+const singleNameInput = document.getElementById('single-name');
 const multiModal = document.getElementById('multi-modal');
 const playerCount = document.getElementById('player-count');
 const nameFields = document.getElementById('name-fields');
@@ -51,7 +52,10 @@ function updateNameFields() {
 playerCount.addEventListener('input', updateNameFields);
 updateNameFields();
 
-document.getElementById('single-mode').onclick = () => startSelectedGame('single');
+document.getElementById('single-mode').onclick = () => {
+  const name = singleNameInput.value.trim() || 'Player 1';
+  startSelectedGame('single', [name]);
+};
 document.getElementById('multi-mode').onclick = () => {
   modeModal.classList.add('hidden');
   multiModal.classList.remove('hidden');

--- a/script.js
+++ b/script.js
@@ -25,7 +25,8 @@ function startGame(mode, names = []) {
       players.push({ name, score: 0 });
     }
   } else {
-    players.push({ name: 'Player 1', score: 0 });
+    const name = names[0] || 'Player 1';
+    players.push({ name, score: 0 });
   }
   currentPlayerIndex = 0;
   document.getElementById('scoreboard').classList.remove('hidden');


### PR DESCRIPTION
## Summary
- let single players enter their name before starting
- clean up exam categories by removing `Chapter` prefixes
- show new single-player name in scoreboard
- document the new name entry feature

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68585f467e588322b908facd7833e554