### PR TITLE
Improve responsiveness of Jeopardy board

### DIFF
--- a/style.css
+++ b/style.css
@@ -36,7 +36,7 @@ body {
 }
 
 .container {
-  max-width: 1200px;
+  width: 100%;
   margin: 80px auto 0;
   padding: 20px;
   text-align: center;
@@ -94,7 +94,7 @@ body {
 
 #jeopardy-board {
   display: grid;
-  grid-template-columns: repeat(5, 1fr);
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
   gap: 10px;
   margin-top: 20px;
 }
@@ -202,4 +202,33 @@ button {
   margin-left: 4px;
   padding: 2px 6px;
   font-size: 14px;
+}
+
+@media (max-width: 600px) {
+  .container {
+    padding: 10px;
+  }
+
+  #top-nav button {
+    padding: 8px 12px;
+    font-size: 14px;
+  }
+
+  #jeopardy-board {
+    gap: 6px;
+  }
+
+  .jeopardy-header,
+  .jeopardy-cell {
+    padding: 10px;
+    font-size: 14px;
+  }
+
+  #scoreboard {
+    font-size: 16px;
+  }
+
+  .player-score button {
+    font-size: 12px;
+  }
 }


### PR DESCRIPTION
## Summary
- allow container to span the full width
- make the board grid flexible and auto‑fit cells
- tweak layout for small screens using a media query

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6858681774bc832284bd61368605110f