### PR TITLE
Add question progress bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,6 +40,7 @@
     <!-- Jeopardy Board and Modals -->
     <div id="jeopardy-board" class="hidden"></div>
     <div id="scoreboard" class="hidden"></div>
+    <div id="progress" class="hidden"><div id="progress-bar"></div></div>
 
     <div id="question-modal" class="hidden">
       <div id="modal-content">

--- a/script.js
+++ b/script.js
@@ -1,5 +1,6 @@
 let currentQuestions = {};
 let remainingQuestions = 0;
+let totalQuestions = 0;
 let players = [];
 let currentPlayerIndex = 0;
 let maxPossibleScore = 0;
@@ -43,6 +44,13 @@ function updateScoreboard() {
     .join(' | ');
 }
 
+function updateProgressBar() {
+  const bar = document.getElementById('progress-bar');
+  const total = totalQuestions || 1;
+  const percent = ((totalQuestions - remainingQuestions) / total) * 100;
+  bar.style.width = percent + '%';
+}
+
 function nextPlayer() {
   currentPlayerIndex = (currentPlayerIndex + 1) % players.length;
   updateScoreboard();
@@ -81,6 +89,10 @@ function buildBoard() {
       board.appendChild(cell);
     });
   });
+
+  totalQuestions = remainingQuestions;
+  document.getElementById('progress').classList.remove('hidden');
+  updateProgressBar();
 }
 
 function showQuestion(questionObj, cell) {
@@ -137,6 +149,7 @@ function closeQuestionModal() {
   document.getElementById('submitted-answer').classList.add('hidden');
   document.getElementById('award-controls').classList.add('hidden');
   remainingQuestions--;
+  updateProgressBar();
   nextPlayer();
 
   if (remainingQuestions === 0) {

--- a/style.css
+++ b/style.css
@@ -203,3 +203,19 @@ button {
   padding: 2px 6px;
   font-size: 14px;
 }
+
+#progress {
+  width: 100%;
+  height: 16px;
+  background-color: #444;
+  border-radius: 8px;
+  overflow: hidden;
+  margin-top: 10px;
+}
+
+#progress-bar {
+  height: 100%;
+  width: 0;
+  background-color: #8e24aa;
+  transition: width 0.3s;
+}


### PR DESCRIPTION
## Summary
- show a progress bar below the scoreboard
- style progress bar in CSS
- update board creation and closing questions to adjust progress bar

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6858682682e48322bdec5b8d0aa22284