### PR TITLE
Add modal answer feedback styles

### DIFF
--- a/script.js
+++ b/script.js
@@ -97,6 +97,7 @@ function showQuestion(questionObj, cell) {
   const awardControls = document.getElementById('award-controls');
   const awardYes = document.getElementById('award-yes');
   const awardNo = document.getElementById('award-no');
+  const modalContent = document.getElementById('modal-content');
 
   userField.classList.remove('hidden');
   submitBtn.classList.remove('hidden');
@@ -116,14 +117,22 @@ function showQuestion(questionObj, cell) {
     awardControls.classList.remove('hidden');
 
     awardYes.onclick = () => {
-      const current = players[currentPlayerIndex];
-      current.score += questionObj.points;
-      updateScoreboard();
-      closeQuestionModal();
+      modalContent.classList.add('answer-correct');
+      document.getElementById('question-modal').classList.add('fade-out');
+      setTimeout(() => {
+        const current = players[currentPlayerIndex];
+        current.score += questionObj.points;
+        updateScoreboard();
+        closeQuestionModal();
+      }, 400);
     };
 
     awardNo.onclick = () => {
-      closeQuestionModal();
+      modalContent.classList.add('answer-wrong');
+      document.getElementById('question-modal').classList.add('fade-out');
+      setTimeout(() => {
+        closeQuestionModal();
+      }, 400);
     };
   };
 
@@ -131,7 +140,11 @@ function showQuestion(questionObj, cell) {
 }
 
 function closeQuestionModal() {
-  document.getElementById('question-modal').classList.add('hidden');
+  const modal = document.getElementById('question-modal');
+  const modalContent = document.getElementById('modal-content');
+  modal.classList.add('hidden');
+  modal.classList.remove('fade-out');
+  modalContent.classList.remove('answer-correct', 'answer-wrong');
   document.getElementById('correct-answer').classList.add('hidden');
   document.getElementById('cancel-btn').classList.add('hidden');
   document.getElementById('submitted-answer').classList.add('hidden');

--- a/style.css
+++ b/style.css
@@ -186,6 +186,25 @@ button {
 #submit-answer { background: #8e24aa; color: white; }
 #cancel-btn, #restart-btn { background: #ba68c8; color: black; }
 
+/* Visual feedback for awarding points */
+#modal-content.answer-correct {
+  background-color: #2e7d32;
+  color: #fff;
+}
+
+#modal-content.answer-wrong {
+  background-color: #c62828;
+  color: #fff;
+}
+
+#question-modal.fade-out {
+  animation: fadeOut 0.4s forwards;
+}
+
+@keyframes fadeOut {
+  to { opacity: 0; }
+}
+
 .site-footer {
   margin: 40px 0 10px 0;
   text-align: center;


### PR DESCRIPTION
## Summary
- provide CSS classes for correct and wrong answers with fade-out effect
- show modal color feedback and fade-out on scoring actions

## Testing
- `npm test` *(fails: could not find `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_685868e10648832290f240e9b0811c64