### PR TITLE
Add landing page 'Who said it?' game

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,6 +37,15 @@
     <h1>Philosophy Review Jeopardy</h1>
     <p id="instructions">Select a topic above to start a new game. Choose an exam type and game mode to challenge yourself or play with friends.</p>
 
+    <div id="quote-game">
+      <h2>Who said it?</h2>
+      <p id="quote-text"></p>
+      <input type="text" id="quote-answer" placeholder="Enter philosopher" autocomplete="off">
+      <button id="quote-submit">Guess</button>
+      <div id="quote-feedback" class="hidden"></div>
+      <button id="quote-next" class="hidden">Next Quote</button>
+    </div>
+
     <!-- Jeopardy Board and Modals -->
     <div id="jeopardy-board" class="hidden"></div>
     <div id="scoreboard" class="hidden"></div>
@@ -105,5 +114,6 @@
   <script src="data/intro-philosophy-final.js"></script>
   <script src="script.js"></script>
   <script src="inline-select.js"></script>
+  <script src="who-said-it.js"></script>
 </body>
 </html>

--- a/inline-select.js
+++ b/inline-select.js
@@ -38,6 +38,7 @@ function startSelectedGame(mode, names = []) {
   document.getElementById('jeopardy-board').classList.remove('hidden');
   document.getElementById('scoreboard').classList.remove('hidden');
   document.getElementById('progress').classList.remove('hidden');
+  document.getElementById('quote-game').classList.add('hidden');
   loadQuestions(selectedTopic, selectedExam);
 }
 
@@ -92,6 +93,8 @@ function goHome() {
   document.getElementById('celebration-modal').classList.add('hidden');
   document.getElementById('scoreboard').classList.add('hidden');
   document.getElementById('progress').classList.add('hidden');
+  document.getElementById('quote-game').classList.remove('hidden');
+  if (typeof showRandomQuote === 'function') showRandomQuote();
   document.querySelectorAll('#topic-selector .exam-dropdown').forEach(dd => dd.classList.add('hidden'));
   document.getElementById('instructions').scrollIntoView();
 }

--- a/style.css
+++ b/style.css
@@ -226,6 +226,24 @@ button {
   transition: width 0.3s ease;
 }
 
+#quote-game {
+  margin-top: 20px;
+}
+
+#quote-text {
+  font-style: italic;
+  margin-bottom: 10px;
+}
+
+#quote-feedback {
+  margin-top: 10px;
+}
+
+#quote-next {
+  background: #ba68c8;
+  color: black;
+}
+
 .player-score button {
   margin-left: 4px;
   padding: 2px 6px;

--- a/who-said-it.js
+++ b/who-said-it.js
@@ -1,0 +1,51 @@
+const philosopherQuotes = [
+  { quote: "The unexamined life is not worth living.", philosopher: "Socrates" },
+  { quote: "I think, therefore I am.", philosopher: "René Descartes" },
+  { quote: "One cannot step twice in the same river.", philosopher: "Heraclitus" },
+  { quote: "Happiness is the highest good.", philosopher: "Aristotle" },
+  { quote: "God is dead! He remains dead! And we have killed him.", philosopher: "Friedrich Nietzsche" },
+  { quote: "Entities should not be multiplied unnecessarily.", philosopher: "William of Ockham" },
+  { quote: "To be is to be perceived.", philosopher: "George Berkeley" },
+  { quote: "Man is condemned to be free.", philosopher: "Jean-Paul Sartre" },
+  { quote: "Hell is other people.", philosopher: "Jean-Paul Sartre" },
+  { quote: "The life of man [is] solitary, poor, nasty, brutish, and short.", philosopher: "Thomas Hobbes" },
+  { quote: "Act only according to that maxim whereby you can at the same time will that it should become a universal law.", philosopher: "Immanuel Kant" },
+  { quote: "I ought never to act except in such a way that I could also will that my maxim should become a universal law.", philosopher: "Immanuel Kant" },
+  { quote: "No man's knowledge here can go beyond his experience.", philosopher: "John Locke" },
+  { quote: "All that is solid melts into air.", philosopher: "Karl Marx" },
+  { quote: "He who thinks great thoughts, often makes great errors.", philosopher: "Martin Heidegger" },
+  { quote: "What is rational is actual, and what is actual is rational.", philosopher: "G.W.F. Hegel" },
+  { quote: "The heart has its reasons, which reason does not know.", philosopher: "Blaise Pascal" },
+  { quote: "That which does not kill us makes us stronger.", philosopher: "Friedrich Nietzsche" },
+  { quote: "Happiness is pleasure and the absence of pain.", philosopher: "Epicurus" },
+  { quote: "Philosophy begins in wonder.", philosopher: "Plato" },
+];
+
+let currentQuote = null;
+
+function showRandomQuote() {
+  const idx = Math.floor(Math.random() * philosopherQuotes.length);
+  currentQuote = philosopherQuotes[idx];
+  document.getElementById('quote-text').innerText = '"' + currentQuote.quote + '"';
+  document.getElementById('quote-answer').value = '';
+  document.getElementById('quote-feedback').classList.add('hidden');
+  document.getElementById('quote-next').classList.add('hidden');
+}
+
+document.getElementById('quote-submit').addEventListener('click', () => {
+  const guess = document.getElementById('quote-answer').value.trim();
+  const feedback = document.getElementById('quote-feedback');
+  if (guess.toLowerCase() === currentQuote.philosopher.toLowerCase()) {
+    feedback.innerText = 'Correct!';
+    feedback.style.color = '#4caf50';
+  } else {
+    feedback.innerText = `Nope, it was ${currentQuote.philosopher}.`;
+    feedback.style.color = '#c62828';
+  }
+  feedback.classList.remove('hidden');
+  document.getElementById('quote-next').classList.remove('hidden');
+});
+
+document.getElementById('quote-next').addEventListener('click', showRandomQuote);
+
+showRandomQuote();


### PR DESCRIPTION
## Summary
- add quote challenge section to landing page
- style new quote game and update nav logic
- hide quote game during Jeopardy sessions
- include philosopher quotes and basic gameplay logic

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68586f11847883229d2c1eb5ecdd8065