### PR TITLE
Add flashcards page

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This repository contains a lightweight browser game that lets you review philoso
 - Modal dialog for answering each question
 - Scoreboard with support for single player or multiplayer teams
 - Single-player mode lets you enter your name, displayed next to your score
+- Simple flashcards page for quick review
 
 ## Getting Started
 
@@ -17,6 +18,8 @@ You can play the game directly from the hosted GitHub Pages site:
 ```
 https://maxaeon.github.io/jeopardy/
 ```
+To study individual questions without the board, open `flashcards.html`. Choose a course and category, then use the buttons to show answers and move to the next card.
+
 
 
 ## Project Structure

--- a/flashcards.html
+++ b/flashcards.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Philosophy Flashcards</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <nav id="top-nav">
+    <button onclick="location.href='index.html'">Back</button>
+  </nav>
+  <div class="container">
+    <h1>Flashcards</h1>
+    <div>
+      <label for="course-select">Course:</label>
+      <select id="course-select">
+        <option value="">--Select--</option>
+        <option value="introPhilosophy">Intro to Philosophy</option>
+        <option value="criticalThinking">Critical Thinking</option>
+        <option value="ethics">Ethics</option>
+      </select>
+      <label for="category-select">Category:</label>
+      <select id="category-select" disabled>
+        <option value="all">All</option>
+      </select>
+    </div>
+
+    <div id="flashcard" class="hidden">
+      <p id="flashcard-question"></p>
+      <p id="flashcard-answer" class="hidden"></p>
+      <button id="show-answer">Show Answer</button>
+      <button id="next-card">Next Card</button>
+    </div>
+  </div>
+
+  <script src="data/ethics.js"></script>
+  <script src="data/ethics-final.js"></script>
+  <script src="data/critical-thinking.js"></script>
+  <script src="data/critical-thinking-midterm.js"></script>
+  <script src="data/critical-thinking-final.js"></script>
+  <script src="data/intro-philosophy.js"></script>
+  <script src="data/intro-philosophy-final.js"></script>
+  <script src="flashcards.js"></script>
+</body>
+</html>

--- a/flashcards.js
+++ b/flashcards.js
@@ -1,0 +1,96 @@
+// Aggregate question sets into a single object keyed by course
+function buildFlashcards() {
+  const courses = ['introPhilosophy', 'criticalThinking', 'ethics'];
+  const flashcards = {};
+
+  courses.forEach(course => {
+    flashcards[course] = {};
+    const variants = [
+      `${course}Questions`,
+      `${course}MidtermQuestions`,
+      `${course}FinalQuestions`
+    ];
+    variants.forEach(name => {
+      const data = window[name];
+      if (data) {
+        Object.keys(data).forEach(cat => {
+          if (!flashcards[course][cat]) flashcards[course][cat] = [];
+          flashcards[course][cat] = flashcards[course][cat].concat(data[cat]);
+        });
+      }
+    });
+  });
+  return flashcards;
+}
+
+const flashcards = buildFlashcards();
+let currentCards = [];
+let cardIndex = 0;
+
+function shuffle(arr) {
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+}
+
+function populateCategories(course) {
+  const catSelect = document.getElementById('category-select');
+  catSelect.innerHTML = '';
+  if (!course || !flashcards[course]) {
+    catSelect.disabled = true;
+    return;
+  }
+  const cats = Object.keys(flashcards[course]);
+  catSelect.appendChild(new Option('All', 'all'));
+  cats.forEach(cat => catSelect.appendChild(new Option(cat, cat)));
+  catSelect.disabled = false;
+}
+
+function loadCards(course, category = 'all') {
+  if (!flashcards[course]) return;
+  const allCards = category === 'all'
+    ? Object.values(flashcards[course]).flat()
+    : (flashcards[course][category] || []);
+  currentCards = allCards.slice();
+  shuffle(currentCards);
+  cardIndex = 0;
+  document.getElementById('flashcard').classList.remove('hidden');
+  loadCard();
+}
+
+function loadCard() {
+  if (!currentCards.length) {
+    document.getElementById('flashcard-question').innerText = 'No cards available.';
+    document.getElementById('flashcard-answer').classList.add('hidden');
+    return;
+  }
+  const card = currentCards[cardIndex];
+  document.getElementById('flashcard-question').innerText = card.question;
+  document.getElementById('flashcard-answer').innerText = card.answer;
+  document.getElementById('flashcard-answer').classList.add('hidden');
+}
+
+function showAnswer() {
+  document.getElementById('flashcard-answer').classList.remove('hidden');
+}
+
+function nextCard() {
+  if (!currentCards.length) return;
+  cardIndex = (cardIndex + 1) % currentCards.length;
+  loadCard();
+}
+
+document.getElementById('course-select').addEventListener('change', e => {
+  const course = e.target.value;
+  populateCategories(course);
+  if (course) loadCards(course);
+});
+
+document.getElementById('category-select').addEventListener('change', e => {
+  const course = document.getElementById('course-select').value;
+  if (course) loadCards(course, e.target.value);
+});
+
+document.getElementById('show-answer').addEventListener('click', showAnswer);
+document.getElementById('next-card').addEventListener('click', nextCard);

--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
 <body>
   <nav id="top-nav">
     <button id="home-btn">Home</button>
+    <button onclick="location.href='flashcards.html'">Flashcards</button>
     <div id="topic-selector">
       <div class="course">
         <button class="topic-btn" data-topic="introPhilosophy">Intro to Philosophy</button>


### PR DESCRIPTION
## Summary
- add a simple flashcards page and script for studying question banks
- aggregate all question banks for flashcard mode
- link flashcards page from the main index
- document flashcards feature in README

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685872bd05c483228631668b8da707b9