### PR TITLE
Organize games by course

### DIFF
--- a/flashcards.js
+++ b/flashcards.js
@@ -94,3 +94,18 @@ document.getElementById('category-select').addEventListener('change', e => {
 
 document.getElementById('show-answer').addEventListener('click', showAnswer);
 document.getElementById('next-card').addEventListener('click', nextCard);
+
+function getParam(name) {
+  const params = new URLSearchParams(window.location.search);
+  return params.get(name);
+}
+
+window.addEventListener('DOMContentLoaded', () => {
+  const course = getParam('course');
+  if (course) {
+    const select = document.getElementById('course-select');
+    select.value = course;
+    populateCategories(course);
+    loadCards(course);
+  }
+});

--- a/index.html
+++ b/index.html
@@ -8,29 +8,42 @@
 <body>
   <nav id="top-nav">
     <button id="home-btn">Home</button>
-    <button onclick="location.href='flashcards.html'">Flashcards</button>
-    <button onclick='location.href="trivia.html"'>Trivia</button>
-    <button onclick="location.href='fallacy.html'">Fallacy Game</button>
     <div id="topic-selector">
       <div class="course">
-        <button class="topic-btn" data-topic="introPhilosophy">Intro to Philosophy</button>
+        <h3>Intro to Philosophy</h3>
+        <button class="topic-btn" data-topic="introPhilosophy">Jeopardy</button>
         <div class="exam-dropdown hidden">
           <button data-exam="Midterm">Midterm Review</button>
           <button data-exam="Final">Final Review</button>
         </div>
+        <div class="game-links">
+          <button onclick="location.href='flashcards.html?course=introPhilosophy'">Flashcards</button>
+          <button onclick="location.href='trivia.html?course=introPhilosophy'">Trivia</button>
+        </div>
       </div>
       <div class="course">
-        <button class="topic-btn" data-topic="criticalThinking">Critical Thinking</button>
+        <h3>Critical Thinking</h3>
+        <button class="topic-btn" data-topic="criticalThinking">Jeopardy</button>
         <div class="exam-dropdown hidden">
           <button data-exam="Midterm">Midterm Review</button>
           <button data-exam="Final">Final Review</button>
         </div>
+        <div class="game-links">
+          <button onclick="location.href='flashcards.html?course=criticalThinking'">Flashcards</button>
+          <button onclick="location.href='trivia.html?course=criticalThinking'">Trivia</button>
+          <button onclick="location.href='fallacy.html'">Fallacy Detective</button>
+        </div>
       </div>
       <div class="course">
-        <button class="topic-btn" data-topic="ethics">Ethics</button>
+        <h3>Ethics</h3>
+        <button class="topic-btn" data-topic="ethics">Jeopardy</button>
         <div class="exam-dropdown hidden">
           <button data-exam="Midterm">Midterm Review</button>
           <button data-exam="Final">Final Review</button>
+        </div>
+        <div class="game-links">
+          <button onclick="location.href='flashcards.html?course=ethics'">Flashcards</button>
+          <button onclick="location.href='trivia.html?course=ethics'">Trivia</button>
         </div>
       </div>
     </div>

--- a/style.css
+++ b/style.css
@@ -62,7 +62,10 @@ body {
 
 .course {
   position: relative;
-  display: inline-block;
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  margin: 0 8px;
 }
 
 .exam-dropdown {
@@ -85,6 +88,16 @@ body {
   color: #000;
   font-size: 14px;
   margin-top: 4px;
+}
+
+.game-links {
+  display: flex;
+  gap: 6px;
+  margin-top: 4px;
+}
+
+.course h3 {
+  margin-bottom: 4px;
 }
 
 #topic-selector button:hover {
@@ -247,6 +260,7 @@ button {
 .mc-options {
   display: flex;
   flex-direction: column;
+  align-items: center;
   gap: 8px;
   margin-top: 10px;
 }

--- a/trivia.js
+++ b/trivia.js
@@ -72,3 +72,17 @@ document.getElementById('trivia-course').addEventListener('change', e => {
     document.getElementById('trivia-game').classList.add('hidden');
   }
 });
+
+function getParam(name) {
+  const params = new URLSearchParams(window.location.search);
+  return params.get(name);
+}
+
+window.addEventListener('DOMContentLoaded', () => {
+  const course = getParam('course');
+  if (course) {
+    const select = document.getElementById('trivia-course');
+    select.value = course;
+    loadTrivia(course);
+  }
+});


### PR DESCRIPTION
## Summary
- reorganize navigation to list Jeopardy, Flashcards and Trivia under each course
- show fallacy game under Critical Thinking
- pass course selection to Flashcards and Trivia pages
- narrow multiple-choice buttons

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6858a56db9f48322b843f6c27aabd74a