### PR TITLE
Add responsive layout for course selector

### DIFF
--- a/style.css
+++ b/style.css
@@ -420,3 +420,15 @@ button {
 .info:hover::after {
   opacity: 1;
 }
+
+@media (min-width: 768px) {
+  #topic-selector {
+    flex-direction: row;
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+
+  .course {
+    margin: 8px;
+  }
+}


### PR DESCRIPTION
## Summary
- make topic selector flex row with wrapping at wider viewports
- keep course cards centered with margin

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6858d7cf0db48322a007bb2dec784972