### PR TITLE
Improve home page layout and accessibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,13 +6,12 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <nav id="top-nav">
+  <nav id="top-nav" aria-label="Main">
     <a id="home-link" href="index.html">Thinker's Arcade</a>
   </nav>
 
-  <div class="container">
-    <img id="site-icon" src="icon.png" alt="Site icon">
-    <h1>Thinker's Arcade</h1>
+  <main class="container">
+    <img id="site-icon" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 80 80'%3E%3Crect width='80' height='80' rx='10' ry='10' fill='%239c27b0'/%3E%3Ctext x='40' y='55' font-size='40' text-anchor='middle' fill='white'%3ETA%3C/text%3E%3C/svg%3E" alt="Thinker's Arcade icon">
     <p id="instructions">Choose a course below to start a new game. Select an exam type and game mode to challenge yourself or play with friends.</p>
     <div id="topic-selector">
       <div class="course">
@@ -67,7 +66,7 @@
 
     <!-- Jeopardy Board and Modals -->
     <div id="jeopardy-board" class="hidden"></div>
-    <div id="scoreboard" class="hidden"></div>
+    <div id="scoreboard" class="hidden" role="status" aria-live="polite"></div>
     <div id="progress" class="hidden"></div>
 
     <div id="question-modal" class="hidden">
@@ -120,7 +119,7 @@
       </div>
     </div>
 
-  </div>
+  </main>
 
   <footer class="site-footer">&copy; <a href="https://www.maparks.com">maxaeon</a> 2025</footer>
 

--- a/inline-select.js
+++ b/inline-select.js
@@ -1,13 +1,19 @@
 // Handles topic dropdown toggling and exam selection on index.html
 
 document.querySelectorAll('#topic-selector .topic-btn').forEach(topicBtn => {
+  const dropdown = topicBtn.nextElementSibling;
+  topicBtn.setAttribute('aria-expanded', 'false');
   topicBtn.addEventListener('click', () => {
-    const dropdown = topicBtn.nextElementSibling;
     // Close other dropdowns
     document.querySelectorAll('#topic-selector .exam-dropdown').forEach(dd => {
-      if (dd !== dropdown) dd.classList.add('hidden');
+      if (dd !== dropdown) {
+        dd.classList.add('hidden');
+        const btn = dd.previousElementSibling;
+        if (btn) btn.setAttribute('aria-expanded', 'false');
+      }
     });
     dropdown.classList.toggle('hidden');
+    topicBtn.setAttribute('aria-expanded', String(!dropdown.classList.contains('hidden')));
   });
 });
 

--- a/style.css
+++ b/style.css
@@ -86,7 +86,7 @@ body {
   display: flex;
   flex-direction: column;
   align-items: center;
-  margin: 0 8px;
+  margin: 0 8px 16px;
   background: #1e1e1e;
   padding: 20px;
   border-radius: 12px;
@@ -95,10 +95,6 @@ body {
 }
 
 .exam-dropdown {
-  position: absolute;
-  top: 100%;
-  left: 0;
-  right: 0;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -106,7 +102,6 @@ body {
   padding: 4px 0;
   border-radius: 8px;
   margin-top: 4px;
-  z-index: 500;
 }
 
 .exam-dropdown button {


### PR DESCRIPTION
## Summary
- clean up the home page heading and add a simple inline icon
- prevent exam dropdowns from overlapping other rows
- expose scoreboard updates to screen readers
- track topic button dropdown state for assistive tech

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6858db75b4dc8322a6d644e4d3ded91a