### PR TITLE
Hide game view when returning home

### DIFF
--- a/inline-select.js
+++ b/inline-select.js
@@ -129,3 +129,6 @@ document.getElementById('quit-yes').onclick = () => {
 document.getElementById('quit-no').onclick = () => {
   quitModal.classList.add('hidden');
 };
+
+// Ensure game view is reset when returning via browser navigation
+window.addEventListener("pageshow", goHome);


### PR DESCRIPTION
## Summary
- reset the home screen whenever the page is shown again

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6858dd69d66083229262d6db93540f43