### PR TITLE
Fix Jeopardy board not hiding on navigation

### DIFF
--- a/inline-select.js
+++ b/inline-select.js
@@ -134,3 +134,11 @@ document.getElementById('quit-no').onclick = () => {
 window.addEventListener("pagehide", goHome);
 // Also reset when the page is shown again from the back/forward cache
 window.addEventListener("pageshow", goHome);
+
+// Ensure the game closes when the page is hidden or unloaded
+document.addEventListener('visibilitychange', () => {
+  if (document.hidden) {
+    goHome();
+  }
+});
+window.addEventListener('beforeunload', goHome);


### PR DESCRIPTION
## Summary
- close the Jeopardy game whenever the page loses focus or unloads

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6859201dc9c08322bbce7bcf826f9c55