### PR TITLE
Add speaker color classes

### DIFF
--- a/ethics-chat-engine.js
+++ b/ethics-chat-engine.js
@@ -5,8 +5,19 @@
   let current = 'Philosophy Student';
   let exchangeIndex = 0;
   const alignmentScores = {};
+  const speakerClasses = {
+    'John Stuart Mill': 'speaker-mill',
+    'Immanuel Kant': 'speaker-kant',
+    'St. Thomas Aquinas': 'speaker-aquinas',
+    'Aristotle': 'speaker-aristotle',
+    'Nel Noddings': 'speaker-noddings',
+    'Philosophy Student': 'speaker-student'
+  };
 
-  function addMessage(speaker, text, className = 'chat-bot') {
+  function addMessage(speaker, text, className) {
+    if (!className) {
+      className = speakerClasses[speaker] || 'chat-bot';
+    }
     const div = document.createElement('div');
     div.className = `chat-message ${className}`;
     div.innerHTML = `<strong>${speaker}:</strong> ${text}`;

--- a/intro-philosophy-chatbot-revised.js
+++ b/intro-philosophy-chatbot-revised.js
@@ -135,8 +135,19 @@ const philosophyChatSteps = [
   const chatBox = document.getElementById('chat-box');
   const controls = document.getElementById('chat-controls');
   let stepIndex = 0;
+  const speakerClasses = {
+    'Philosophy Student': 'speaker-student',
+    'Thales': 'speaker-thales',
+    'Heraclitus': 'speaker-heraclitus',
+    'Socrates': 'speaker-socrates',
+    'Plato': 'speaker-plato',
+    'Aristotle': 'speaker-aristotle'
+  };
 
-  function addMessage(speaker, text, className = 'chat-bot') {
+  function addMessage(speaker, text, className) {
+    if (!className) {
+      className = speakerClasses[speaker] || 'chat-bot';
+    }
     const div = document.createElement('div');
     div.className = `chat-message ${className}`;
     div.innerHTML = `<strong>${speaker}:</strong> ${text}`;

--- a/style.css
+++ b/style.css
@@ -382,6 +382,47 @@ button {
   color: #80cbc4;
 }
 
+/* Individual speaker colors */
+.speaker-mill {
+  color: #4caf50;
+}
+
+.speaker-kant {
+  color: #ff9800;
+}
+
+.speaker-aquinas {
+  color: #f44336;
+}
+
+.speaker-aristotle {
+  color: #ffeb3b;
+}
+
+.speaker-noddings {
+  color: #e91e63;
+}
+
+.speaker-student {
+  color: #9c27b0;
+}
+
+.speaker-thales {
+  color: #2196f3;
+}
+
+.speaker-heraclitus {
+  color: #ff5722;
+}
+
+.speaker-socrates {
+  color: #009688;
+}
+
+.speaker-plato {
+  color: #795548;
+}
+
 .typing {
   opacity: 0.6;
   font-style: italic;


### PR DESCRIPTION
## Summary
- style speaker chat messages with unique colors
- auto-apply speaker styles in ethics and philosophy chat scripts

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685925c42ddc832289b39eb51a937c3c