### PR TITLE
Add typing delay to chat bot responses

### DIFF
--- a/ethics-chat-engine.js
+++ b/ethics-chat-engine.js
@@ -14,15 +14,24 @@
     'Philosophy Student': 'speaker-student'
   };
 
-  function addMessage(speaker, text, className) {
+  async function addMessage(speaker, text, className) {
     if (!className) {
       className = speakerClasses[speaker] || 'chat-bot';
     }
     const div = document.createElement('div');
     div.className = `chat-message ${className}`;
-    div.innerHTML = `<strong>${speaker}:</strong> ${text}`;
-    chatBox.appendChild(div);
-    chatBox.scrollTop = chatBox.scrollHeight;
+    if (div.classList.contains('chat-bot')) {
+      div.innerHTML = `<strong>${speaker}:</strong> <span class="typing">…</span>`;
+      chatBox.appendChild(div);
+      chatBox.scrollTop = chatBox.scrollHeight;
+      await new Promise(res => setTimeout(res, 1000));
+      div.innerHTML = `<strong>${speaker}:</strong> ${text}`;
+      chatBox.scrollTop = chatBox.scrollHeight;
+    } else {
+      div.innerHTML = `<strong>${speaker}:</strong> ${text}`;
+      chatBox.appendChild(div);
+      chatBox.scrollTop = chatBox.scrollHeight;
+    }
   }
 
   function showOptions(responses, view) {
@@ -36,9 +45,9 @@
     });
   }
 
-  function handleChoice(option, reply, view) {
-    addMessage('You', option, 'chat-user');
-    addMessage(current, reply);
+  async function handleChoice(option, reply, view) {
+    await addMessage('You', option, 'chat-user');
+    await addMessage(current, reply);
     if (option === view) {
       alignmentScores[current] = (alignmentScores[current] || 0) + 1;
     }
@@ -46,7 +55,7 @@
     setTimeout(showExchange, 500);
   }
 
-  function showExchange() {
+  async function showExchange() {
     const data = bots[current];
     const exchanges = data.exchanges || [];
     if (exchangeIndex >= exchanges.length) {
@@ -61,13 +70,13 @@
         } else {
           closing = data.closings.lowAlignment('');
         }
-        addMessage(current, closing);
+        await addMessage(current, closing);
       }
       current = data.nextTheorist;
       exchangeIndex = 0;
       if (current === 'Philosophy Student') {
         const finalText = bots['Philosophy Student'].finalAssessment('', alignmentScores);
-        addMessage('Philosophy Student', finalText);
+        await addMessage('Philosophy Student', finalText);
         controls.innerHTML = '';
         return;
       }
@@ -75,29 +84,29 @@
       const greet = typeof bots[current].greeting === 'function'
         ? bots[current].greeting('')
         : bots[current].greeting;
-      addMessage(current, greet);
+      await addMessage(current, greet);
       setTimeout(showExchange, 500);
       return;
     }
     const ex = exchanges[exchangeIndex];
-    if (ex.transition) addMessage(current, ex.transition);
-    addMessage(current, ex.question);
+    if (ex.transition) await addMessage(current, ex.transition);
+    await addMessage(current, ex.question);
     showOptions(ex.responses, ex.theoristView);
   }
 
-  function startConversation() {
+  async function startConversation() {
     const student = bots['Philosophy Student'];
     const greet = typeof student.greeting === 'function' ? student.greeting('') : student.greeting;
-    addMessage('Philosophy Student', greet);
+    await addMessage('Philosophy Student', greet);
     if (student.introduceMill) {
-      addMessage('Philosophy Student', student.introduceMill);
+      await addMessage('Philosophy Student', student.introduceMill);
     }
     current = 'John Stuart Mill';
     alignmentScores[current] = 0;
     const firstGreet = typeof bots[current].greeting === 'function'
       ? bots[current].greeting('')
       : bots[current].greeting;
-    addMessage(current, firstGreet);
+    await addMessage(current, firstGreet);
     showExchange();
   }
 

--- a/intro-philosophy-chatbot-revised.js
+++ b/intro-philosophy-chatbot-revised.js
@@ -144,15 +144,24 @@ const philosophyChatSteps = [
     'Aristotle': 'speaker-aristotle'
   };
 
-  function addMessage(speaker, text, className) {
+  async function addMessage(speaker, text, className) {
     if (!className) {
       className = speakerClasses[speaker] || 'chat-bot';
     }
     const div = document.createElement('div');
     div.className = `chat-message ${className}`;
-    div.innerHTML = `<strong>${speaker}:</strong> ${text}`;
-    chatBox.appendChild(div);
-    chatBox.scrollTop = chatBox.scrollHeight;
+    if (div.classList.contains('chat-bot')) {
+      div.innerHTML = `<strong>${speaker}:</strong> <span class="typing">…</span>`;
+      chatBox.appendChild(div);
+      chatBox.scrollTop = chatBox.scrollHeight;
+      await new Promise(res => setTimeout(res, 1000));
+      div.innerHTML = `<strong>${speaker}:</strong> ${text}`;
+      chatBox.scrollTop = chatBox.scrollHeight;
+    } else {
+      div.innerHTML = `<strong>${speaker}:</strong> ${text}`;
+      chatBox.appendChild(div);
+      chatBox.scrollTop = chatBox.scrollHeight;
+    }
   }
 
   function showChoices(step) {
@@ -166,14 +175,18 @@ const philosophyChatSteps = [
     });
   }
 
-  function handleChoice(choice) {
-    addMessage('You', choice, 'chat-user');
+  async function handleChoice(choice) {
+    await addMessage('You', choice, 'chat-user');
     const step = philosophyChatSteps[stepIndex];
     controls.innerHTML = '';
     const replies = step.responses[choice] || [];
-    replies.forEach(m => addMessage(m.speaker, m.text));
+    for (const m of replies) {
+      await addMessage(m.speaker, m.text);
+    }
     if (step.after) {
-      step.after.forEach(m => addMessage(m.speaker, m.text));
+      for (const m of step.after) {
+        await addMessage(m.speaker, m.text);
+      }
     }
     stepIndex++;
     if (stepIndex < philosophyChatSteps.length) {
@@ -181,14 +194,18 @@ const philosophyChatSteps = [
     }
   }
 
-  function showStep() {
+  async function showStep() {
     const step = philosophyChatSteps[stepIndex];
-    step.messages.forEach(m => addMessage(m.speaker, m.text));
+    for (const m of step.messages) {
+      await addMessage(m.speaker, m.text);
+    }
     if (step.choices) {
       showChoices(step);
     } else {
       if (step.after) {
-        step.after.forEach(m => addMessage(m.speaker, m.text));
+        for (const m of step.after) {
+          await addMessage(m.speaker, m.text);
+        }
       }
       stepIndex++;
       if (stepIndex < philosophyChatSteps.length) {


### PR DESCRIPTION
## Summary
- show a typing indicator for bot messages in Ethics and Intro Philosophy chat engines
- wait for the typing delay before displaying subsequent messages

## Testing
- `node --check ethics-chat-engine.js`
- `node --check intro-philosophy-chatbot-revised.js`


------
https://chatgpt.com/codex/tasks/task_e_6859265a09e08322a0b99f4711704a07