### PR TITLE
Fix chat typing indicator delay

### DIFF
--- a/chat-ui.js
+++ b/chat-ui.js
@@ -36,7 +36,7 @@ document.addEventListener('DOMContentLoaded', () => {
     typing.textContent = '…';
     chatBox.appendChild(typing);
     chatBox.scrollTop = chatBox.scrollHeight;
-    const delay = 1000 + Math.random() * 1000; // 1-2 seconds
+    const delay = 1000 + Math.random() * 1500; // 1-2.5 seconds
     setTimeout(() => {
       typing.textContent = message;
     }, delay);

--- a/ethics-chat-engine.js
+++ b/ethics-chat-engine.js
@@ -20,11 +20,12 @@
     }
     const div = document.createElement('div');
     div.className = `chat-message ${className}`;
-    if (div.classList.contains('chat-bot')) {
+    if (speaker !== 'You') {
       div.innerHTML = `<strong>${speaker}:</strong> <span class="typing">…</span>`;
       chatBox.appendChild(div);
       chatBox.scrollTop = chatBox.scrollHeight;
-      await new Promise(res => setTimeout(res, 1000));
+      const delay = 1000 + Math.random() * 1500;
+      await new Promise(res => setTimeout(res, delay));
       div.innerHTML = `<strong>${speaker}:</strong> ${text}`;
       chatBox.scrollTop = chatBox.scrollHeight;
     } else {

--- a/intro-philosophy-chatbot-revised.js
+++ b/intro-philosophy-chatbot-revised.js
@@ -150,11 +150,12 @@ const philosophyChatSteps = [
     }
     const div = document.createElement('div');
     div.className = `chat-message ${className}`;
-    if (div.classList.contains('chat-bot')) {
+    if (speaker !== 'You') {
       div.innerHTML = `<strong>${speaker}:</strong> <span class="typing">…</span>`;
       chatBox.appendChild(div);
       chatBox.scrollTop = chatBox.scrollHeight;
-      await new Promise(res => setTimeout(res, 1000));
+      const delay = 1000 + Math.random() * 1500;
+      await new Promise(res => setTimeout(res, delay));
       div.innerHTML = `<strong>${speaker}:</strong> ${text}`;
       chatBox.scrollTop = chatBox.scrollHeight;
     } else {


### PR DESCRIPTION
## Summary
- update delay for typing indicators to 1–2.5s
- always show typing indicator for bot messages

## Testing
- `node -c ethics-chat-engine.js`
- `node -c intro-philosophy-chatbot-revised.js`
- `node -c chat-ui.js`


------
https://chatgpt.com/codex/tasks/task_e_68592b0184988322b64748fe62b2b490