### PR TITLE
Add avatar support for chatbots

### DIFF
--- a/ethics-chat-engine.js
+++ b/ethics-chat-engine.js
@@ -14,21 +14,32 @@
     'Philosophy Student': 'speaker-student'
   };
 
+  const avatarPaths = {
+    'John Stuart Mill': 'avatars/mill.png',
+    'Immanuel Kant': 'avatars/kant.png',
+    'St. Thomas Aquinas': 'avatars/aquinas.png',
+    'Aristotle': 'avatars/aristotle.png',
+    'Nel Noddings': 'avatars/noddings.png',
+    'Philosophy Student': 'avatars/student.png',
+    'You': 'avatars/user.png'
+  };
+
   async function addMessage(speaker, text, className) {
     if (!className) {
       className = speakerClasses[speaker] || 'chat-bot';
     }
     const div = document.createElement('div');
     div.className = `chat-message ${className}`;
+    const avatar = avatarPaths[speaker] || 'avatars/placeholder.png';
     if (div.classList.contains('chat-bot')) {
-      div.innerHTML = `<strong>${speaker}:</strong> <span class="typing">…</span>`;
+      div.innerHTML = `<img class="avatar" src="${avatar}" alt="${speaker}"> <strong>${speaker}:</strong> <span class="typing">…</span>`;
       chatBox.appendChild(div);
       chatBox.scrollTop = chatBox.scrollHeight;
       await new Promise(res => setTimeout(res, 1000));
-      div.innerHTML = `<strong>${speaker}:</strong> ${text}`;
+      div.innerHTML = `<img class="avatar" src="${avatar}" alt="${speaker}"> <strong>${speaker}:</strong> ${text}`;
       chatBox.scrollTop = chatBox.scrollHeight;
     } else {
-      div.innerHTML = `<strong>${speaker}:</strong> ${text}`;
+      div.innerHTML = `<img class="avatar" src="${avatar}" alt="${speaker}"> <strong>${speaker}:</strong> ${text}`;
       chatBox.appendChild(div);
       chatBox.scrollTop = chatBox.scrollHeight;
     }

--- a/intro-philosophy-chatbot-revised.js
+++ b/intro-philosophy-chatbot-revised.js
@@ -144,21 +144,32 @@ const philosophyChatSteps = [
     'Aristotle': 'speaker-aristotle'
   };
 
+  const avatarPaths = {
+    'Philosophy Student': 'avatars/student.png',
+    'Thales': 'avatars/thales.png',
+    'Heraclitus': 'avatars/heraclitus.png',
+    'Socrates': 'avatars/socrates.png',
+    'Plato': 'avatars/plato.png',
+    'Aristotle': 'avatars/aristotle.png',
+    'You': 'avatars/user.png'
+  };
+
   async function addMessage(speaker, text, className) {
     if (!className) {
       className = speakerClasses[speaker] || 'chat-bot';
     }
     const div = document.createElement('div');
     div.className = `chat-message ${className}`;
+    const avatar = avatarPaths[speaker] || 'avatars/placeholder.png';
     if (div.classList.contains('chat-bot')) {
-      div.innerHTML = `<strong>${speaker}:</strong> <span class="typing">…</span>`;
+      div.innerHTML = `<img class="avatar" src="${avatar}" alt="${speaker}"> <strong>${speaker}:</strong> <span class="typing">…</span>`;
       chatBox.appendChild(div);
       chatBox.scrollTop = chatBox.scrollHeight;
       await new Promise(res => setTimeout(res, 1000));
-      div.innerHTML = `<strong>${speaker}:</strong> ${text}`;
+      div.innerHTML = `<img class="avatar" src="${avatar}" alt="${speaker}"> <strong>${speaker}:</strong> ${text}`;
       chatBox.scrollTop = chatBox.scrollHeight;
     } else {
-      div.innerHTML = `<strong>${speaker}:</strong> ${text}`;
+      div.innerHTML = `<img class="avatar" src="${avatar}" alt="${speaker}"> <strong>${speaker}:</strong> ${text}`;
       chatBox.appendChild(div);
       chatBox.scrollTop = chatBox.scrollHeight;
     }

--- a/style.css
+++ b/style.css
@@ -351,6 +351,16 @@ button {
 
 .chat-message {
   margin: 6px 0;
+  display: flex;
+  align-items: flex-start;
+}
+
+.avatar {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  margin-right: 8px;
+  object-fit: cover;
 }
 
 .chat-user {


### PR DESCRIPTION
## Summary
- add `avatars/` directory for asset images
- show avatars in Ethics Chat and Intro Philosophy Chat
- update chat message display styles

## Testing
- `npm test` *(fails: package.json missing and network blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68592b0129188322a0a47bbb200e73b8