### PR TITLE
Add ethics argument reconstruction activity

### DIFF
--- a/argument-reconstruction/ethics.html
+++ b/argument-reconstruction/ethics.html
@@ -1,0 +1,166 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Argument Reconstruction - Ethics</title>
+  <link rel="stylesheet" href="../jeopardy/style.css">
+  <link rel="icon" href="../favicon.png" type="image/png">
+</head>
+<body>
+  <nav id="top-nav">
+    <a id="home-link" href="../index.html">Thinker's Arcade</a>
+  </nav>
+  <div class="container">
+    <h1>Argument Reconstruction Activity</h1>
+    <p>This activity lets you practice identifying premises and conclusions, distinguishing moral from nonmoral premises, and evaluating arguments. It follows Lewis Vaughn's guideline that moral arguments typically include at least one moral and one nonmoral premise.</p>
+
+    <section id="exercise1">
+      <h2>Exercise 1</h2>
+      <p><em>"Animal cruelty causes unnecessary suffering. Causing unnecessary suffering is morally wrong. Therefore, animal cruelty is morally wrong."</em></p>
+      <textarea rows="3" style="width:90%;" placeholder="Your analysis..."></textarea><br>
+      <button class="reveal-btn" data-target="answer1">Show Ideal Analysis</button>
+      <div id="answer1" class="hidden">
+        <p><strong>Premises:</strong></p>
+        <ol>
+          <li>Animal cruelty causes unnecessary suffering.</li>
+          <li>Causing unnecessary suffering is morally wrong.</li>
+        </ol>
+        <p><strong>Conclusion:</strong> Animal cruelty is morally wrong.</p>
+        <p><strong>Argument Type:</strong> Deductive.</p>
+        <p><strong>Evaluation:</strong> Valid and sound.</p>
+        <p><strong>Moral Premise:</strong> Causing unnecessary suffering is morally wrong.</p>
+        <p><strong>Nonmoral Premise:</strong> Animal cruelty causes unnecessary suffering.</p>
+      </div>
+    </section>
+
+    <section id="exercise2">
+      <h2>Exercise 2</h2>
+      <p><em>"Most philosophers teach logic. Dr. Lee is a philosopher. Thus, Dr. Lee probably teaches logic."</em></p>
+      <textarea rows="3" style="width:90%;" placeholder="Your analysis..."></textarea><br>
+      <button class="reveal-btn" data-target="answer2">Show Ideal Analysis</button>
+      <div id="answer2" class="hidden">
+        <p><strong>Premises:</strong></p>
+        <ol>
+          <li>Most philosophers teach logic.</li>
+          <li>Dr. Lee is a philosopher.</li>
+        </ol>
+        <p><strong>Conclusion:</strong> Dr. Lee probably teaches logic.</p>
+        <p><strong>Argument Type:</strong> Inductive.</p>
+        <p><strong>Evaluation:</strong> Strong and cogent if the premises are accurate.</p>
+      </div>
+    </section>
+
+    <section id="exercise3">
+      <h2>Exercise 3</h2>
+      <p><em>"Factory farming causes severe animal suffering. Causing unnecessary animal suffering is morally wrong. Therefore, factory farming is morally wrong."</em></p>
+      <textarea rows="3" style="width:90%;" placeholder="Your analysis..."></textarea><br>
+      <button class="reveal-btn" data-target="answer3">Show Ideal Analysis</button>
+      <div id="answer3" class="hidden">
+        <p><strong>Nonmoral premise:</strong> Factory farming causes severe animal suffering.</p>
+        <p><strong>Moral premise:</strong> Causing unnecessary animal suffering is morally wrong.</p>
+        <p><strong>Conclusion:</strong> Factory farming is morally wrong.</p>
+      </div>
+    </section>
+
+    <section id="exercise4">
+      <h2>Exercise 4</h2>
+      <p><em>"Genetic modification alters organisms profoundly. Therefore, genetic modification is morally wrong."</em></p>
+      <textarea rows="3" style="width:90%;" placeholder="Your analysis..."></textarea><br>
+      <button class="reveal-btn" data-target="answer4">Show Ideal Analysis</button>
+      <div id="answer4" class="hidden">
+        <p>Missing a moral premise explaining why profound alteration is morally problematic.</p>
+      </div>
+    </section>
+
+    <section id="exercise5">
+      <h2>Exercise 5</h2>
+      <p><em>"All harm is morally unacceptable. Therefore, recreational hunting is morally unacceptable."</em></p>
+      <textarea rows="3" style="width:90%;" placeholder="Your analysis..."></textarea><br>
+      <button class="reveal-btn" data-target="answer5">Show Ideal Analysis</button>
+      <div id="answer5" class="hidden">
+        <p>Missing a nonmoral premise clearly stating that recreational hunting causes harm.</p>
+      </div>
+    </section>
+
+    <section id="exercise6">
+      <h2>Exercise 6</h2>
+      <p><em>"All humans deserve basic respect. Therefore, John deserves basic respect."</em></p>
+      <textarea rows="3" style="width:90%;" placeholder="Your analysis..."></textarea><br>
+      <button class="reveal-btn" data-target="answer6">Show Ideal Analysis</button>
+      <div id="answer6" class="hidden">
+        <p>This initially looks like a moral-to-moral argument lacking a nonmoral premise. The hidden premise is that John is human. Stating it explicitly aligns with Vaughn's criterion.</p>
+      </div>
+    </section>
+
+    <section id="exercise7">
+      <h2>Exercise 7</h2>
+      <p><em>"All unnecessary suffering is morally wrong. Therefore, torture is morally wrong."</em></p>
+      <textarea rows="3" style="width:90%;" placeholder="Your analysis..."></textarea><br>
+      <button class="reveal-btn" data-target="answer7">Show Ideal Analysis</button>
+      <div id="answer7" class="hidden">
+        <p>The argument requires the implicit nonmoral premise that torture causes unnecessary suffering. Making it explicit resolves the counterexample.</p>
+      </div>
+    </section>
+
+    <section id="exercise8">
+      <h2>Exercise 8</h2>
+      <p><em>"All mammals are warm-blooded. Whales are mammals. Therefore, whales are warm-blooded."</em></p>
+      <textarea rows="3" style="width:90%;" placeholder="Your analysis..."></textarea><br>
+      <button class="reveal-btn" data-target="answer8">Show Ideal Analysis</button>
+      <div id="answer8" class="hidden">
+        <p><strong>Type:</strong> Deductive.</p>
+        <p><strong>Validity:</strong> Valid.</p>
+        <p><strong>Soundness:</strong> Sound.</p>
+      </div>
+    </section>
+
+    <section id="exercise9">
+      <h2>Exercise 9</h2>
+      <p><em>"Most ethics students pass exams. Maria is an ethics student. Maria will likely pass the exam."</em></p>
+      <textarea rows="3" style="width:90%;" placeholder="Your analysis..."></textarea><br>
+      <button class="reveal-btn" data-target="answer9">Show Ideal Analysis</button>
+      <div id="answer9" class="hidden">
+        <p><strong>Type:</strong> Inductive.</p>
+        <p><strong>Strength:</strong> Strong if the premises are true.</p>
+        <p><strong>Cogency:</strong> Cogent when the premises are factually accurate.</p>
+      </div>
+    </section>
+
+    <section id="exercise10">
+      <h2>Exercise 10</h2>
+      <p><em>"All birds fly. Penguins are birds. Thus, penguins fly."</em></p>
+      <textarea rows="3" style="width:90%;" placeholder="Your analysis..."></textarea><br>
+      <button class="reveal-btn" data-target="answer10">Show Ideal Analysis</button>
+      <div id="answer10" class="hidden">
+        <p><strong>Validity:</strong> Valid.</p>
+        <p><strong>Soundness:</strong> Unsound because the first premise is false.</p>
+      </div>
+    </section>
+
+    <section id="exercise11">
+      <h2>Exercise 11</h2>
+      <p><em>"Nearly all philosophers are wealthy. Jane is a philosopher. Thus, Jane is probably wealthy."</em></p>
+      <textarea rows="3" style="width:90%;" placeholder="Your analysis..."></textarea><br>
+      <button class="reveal-btn" data-target="answer11">Show Ideal Analysis</button>
+      <div id="answer11" class="hidden">
+        <p><strong>Strength:</strong> Strong.</p>
+        <p><strong>Cogency:</strong> Not cogent because the premise is false.</p>
+      </div>
+    </section>
+
+    <section id="reflection">
+      <h2>Reflective Prompt</h2>
+      <p>Do you believe Vaughn’s criterion—that moral arguments require explicit moral and nonmoral premises—is always correct? Can you identify an argument that challenges or supports this claim?</p>
+      <textarea rows="3" style="width:90%;" placeholder="Your reflection..."></textarea>
+    </section>
+
+    <section id="summary">
+      <h2>Summary</h2>
+      <p>Moral arguments with moral conclusions typically require both moral and nonmoral premises. Arguments missing one type of premise rely on hidden assumptions. Making those premises explicit helps evaluate validity, soundness, strength, and cogency.</p>
+    </section>
+
+  </div>
+
+  <script src="ethics.js"></script>
+</body>
+</html>

--- a/argument-reconstruction/ethics.js
+++ b/argument-reconstruction/ethics.js
@@ -1,0 +1,12 @@
+// Reveal answer for each exercise
+function setupReconstruction() {
+  document.querySelectorAll('.reveal-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const target = btn.dataset.target;
+      const ans = document.getElementById(target);
+      if (ans) ans.classList.remove('hidden');
+    });
+  });
+}
+
+document.addEventListener('DOMContentLoaded', setupReconstruction);

--- a/index.html
+++ b/index.html
@@ -41,6 +41,7 @@
           <a class="button" href="flashcards/flashcards.html?course=ethics">Flashcards</a>
           <a class="button" href="trivia/trivia.html?course=ethics">Trivia</a>
           <a class="button" href="chatbots/ethics-chat.html">Chat</a>
+          <a class="button" href="argument-reconstruction/ethics.html">Reconstruction</a>
         </div>
       </div>
       <div class="course">


### PR DESCRIPTION
## Summary
- add new Argument Reconstruction activity for Ethics course
- include revealable analyses and reflective prompt
- update homepage to link to the new activity

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685943a63b2883229cbe582273debeac