### PR TITLE
Add info modal and new feedback flow

### DIFF
--- a/argument-reconstruction/ethics.html
+++ b/argument-reconstruction/ethics.html
@@ -12,6 +12,7 @@
   </nav>
   <div class="container">
     <h1>Argument Reconstruction Activity</h1>
+    <button id="info-btn">Info</button>
     <p>This activity lets you practice identifying premises and conclusions, distinguishing moral from nonmoral premises, and evaluating arguments. It follows Lewis Vaughn's guideline that moral arguments typically include at least one moral and one nonmoral premise.</p>
 
     <div id="reconstruction-game">
@@ -19,6 +20,8 @@
       <p id="reconstruction-question"></p>
       <div id="reconstruction-options" class="mc-options"></div>
       <div id="reconstruction-feedback" class="hidden"></div>
+      <button id="reconstruction-try" class="hidden">Try Again</button>
+      <button id="reconstruction-show" class="hidden">Show Answer</button>
       <button id="reconstruction-next" class="hidden">Next</button>
     </div>
 
@@ -29,6 +32,14 @@
         <p>Identifying hidden or missing premises helps clarify whether an argument succeeds according to these standards.</p>
       </section>
 
+  </div>
+
+  <div id="info-modal" class="hidden">
+    <div class="modal-content">
+      <h2>How to Play</h2>
+      <p>Read each argument carefully and choose the option that best answers the question. If you get it wrong, select "Try Again" to attempt the same question or "Show Answer" to reveal the correct response.</p>
+      <button id="close-info">Close</button>
+    </div>
   </div>
 
   <script src="ethics.js"></script>

--- a/argument-reconstruction/ethics.js
+++ b/argument-reconstruction/ethics.js
@@ -154,20 +154,26 @@ function showReconstructionQuestion() {
   });
   document.getElementById("reconstruction-feedback").classList.add("hidden");
   document.getElementById("reconstruction-next").classList.add("hidden");
+  document.getElementById("reconstruction-try").classList.add("hidden");
+  document.getElementById("reconstruction-show").classList.add("hidden");
 }
 
 function submitReconstruction(choice) {
   const q = reconstructionOrder[reconstructionIndex];
   const feedback = document.getElementById("reconstruction-feedback");
+  const options = document.querySelectorAll("#reconstruction-options button");
+  options.forEach(btn => btn.disabled = true);
   if (choice === q.answer) {
     feedback.innerText = "Correct!";
     feedback.style.color = "#4caf50";
+    document.getElementById("reconstruction-next").classList.remove("hidden");
   } else {
-    feedback.innerText = `Incorrect. The correct answer is ${q.answer}.`;
+    feedback.innerText = "Incorrect.";
     feedback.style.color = "#c62828";
+    document.getElementById("reconstruction-try").classList.remove("hidden");
+    document.getElementById("reconstruction-show").classList.remove("hidden");
   }
   feedback.classList.remove("hidden");
-  document.getElementById("reconstruction-next").classList.remove("hidden");
 }
 
 document.getElementById("reconstruction-next").addEventListener("click", () => {
@@ -175,4 +181,28 @@ document.getElementById("reconstruction-next").addEventListener("click", () => {
   showReconstructionQuestion();
 });
 
+document.getElementById("reconstruction-try").addEventListener("click", () => {
+  const options = document.querySelectorAll("#reconstruction-options button");
+  options.forEach(btn => btn.disabled = false);
+  document.getElementById("reconstruction-feedback").classList.add("hidden");
+  document.getElementById("reconstruction-try").classList.add("hidden");
+  document.getElementById("reconstruction-show").classList.add("hidden");
+});
+
+document.getElementById("reconstruction-show").addEventListener("click", () => {
+  const q = reconstructionOrder[reconstructionIndex];
+  document.getElementById("reconstruction-feedback").innerText = `The correct answer is ${q.answer}.`;
+  document.getElementById("reconstruction-show").classList.add("hidden");
+  document.getElementById("reconstruction-try").classList.add("hidden");
+  document.getElementById("reconstruction-next").classList.remove("hidden");
+});
+
 document.addEventListener("DOMContentLoaded", startReconstruction);
+
+// Info modal logic
+document.getElementById("info-btn").addEventListener("click", () => {
+  document.getElementById("info-modal").classList.remove("hidden");
+});
+document.getElementById("close-info").addEventListener("click", () => {
+  document.getElementById("info-modal").classList.add("hidden");
+});


### PR DESCRIPTION
## Summary
- add Info modal to ethics reconstruction game
- show Try Again/Show Answer buttons after wrong answers
- hide or reveal the correct answer only when chosen
- wire up info modal open/close logic

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685952e03ce883229e24e7c59e3ece8d