### PR TITLE
Add timeline ticks and labels

### DIFF
--- a/jeopardy/style.css
+++ b/jeopardy/style.css
@@ -523,7 +523,7 @@ button {
 /* Interactive timeline styles */
 #timeline-container {
   position: relative;
-  height: 40px;
+  height: 80px;
   margin-top: 30px;
 }
 
@@ -531,7 +531,7 @@ button {
   position: absolute;
   left: 0;
   right: 0;
-  top: 15px;
+  top: 35px;
   height: 10px;
   background: linear-gradient(to right, #4caf50, #ff9800, #e91e63);
   border-radius: 5px;
@@ -539,7 +539,7 @@ button {
 
 #timeline-highlight {
   position: absolute;
-  top: 15px;
+  top: 35px;
   height: 10px;
   background: rgba(255, 255, 255, 0.7);
   border-radius: 5px;
@@ -559,6 +559,48 @@ button {
   pointer-events: none;
   transition: opacity 0.2s;
   font-size: 14px;
+}
+
+#timeline-ticks {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 20px;
+  pointer-events: none;
+}
+
+.timeline-tick {
+  position: absolute;
+  bottom: 0;
+  width: 1px;
+  height: 8px;
+  background: #fff;
+}
+
+.tick-label {
+  position: absolute;
+  bottom: 10px;
+  transform: translateX(-50%);
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+#philosopher-labels {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  height: 20px;
+  pointer-events: none;
+}
+
+.philosopher-label {
+  position: absolute;
+  top: 0;
+  transform: translateX(-50%);
+  font-size: 12px;
+  white-space: nowrap;
 }
 
 @media (min-width: 768px) {

--- a/timeline/timeline.html
+++ b/timeline/timeline.html
@@ -57,6 +57,8 @@
       <div id="timeline-bar"></div>
       <div id="timeline-highlight"></div>
       <div id="timeline-tooltip"></div>
+      <div id="timeline-ticks"></div>
+      <div id="philosopher-labels"></div>
     </div>
   </div>
   <script src="timeline.js"></script>

--- a/timeline/timeline.js
+++ b/timeline/timeline.js
@@ -457,7 +457,50 @@ function initTimelineHover() {
   });
 }
 
+function formatYear(year) {
+  if (year >= 1) {
+    return year - 1; // adjust for missing year zero
+  }
+  if (year === 0) {
+    return 1;
+  }
+  return `${Math.abs(year)} BCE`;
+}
+
+function initLabels() {
+  const ticks = document.getElementById('timeline-ticks');
+  const labels = document.getElementById('philosopher-labels');
+  ticks.innerHTML = '';
+  labels.innerHTML = '';
+  const range = timelineEnd - timelineStart;
+  const step = 500;
+  let firstTick = Math.ceil(timelineStart / step) * step;
+  for (let y = firstTick; y <= timelineEnd; y += step) {
+    const tick = document.createElement('div');
+    tick.className = 'timeline-tick';
+    const left = ((y - timelineStart) / range) * 100;
+    tick.style.left = `${left}%`;
+    const lbl = document.createElement('span');
+    lbl.className = 'tick-label';
+    const display = formatYear(y);
+    lbl.textContent = display;
+    tick.appendChild(lbl);
+    ticks.appendChild(tick);
+  }
+
+  philosophyTimeline.forEach(p => {
+    const label = document.createElement('div');
+    label.className = 'philosopher-label';
+    label.textContent = p.name;
+    const mid = (p.startYear + p.endYear) / 2;
+    const pos = ((mid - timelineStart) / range) * 100;
+    label.style.left = `${pos}%`;
+    labels.appendChild(label);
+  });
+}
+
 window.addEventListener('DOMContentLoaded', () => {
   displayEntry(currentIndex);
   initTimelineHover();
+  initLabels();
 });


### PR DESCRIPTION
## Summary
- add tick/label containers to timeline.html
- render 500-year increments and philosopher labels in timeline.js
- style year ticks and philosopher labels
- adjust timeline bar position and container height

## Testing
- `npm test` *(fails: cannot find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68595406bb988322877d8581d8f18d03