### PR TITLE
Remove philosopher label elements from timeline

### DIFF
--- a/jeopardy/style.css
+++ b/jeopardy/style.css
@@ -593,22 +593,7 @@ button {
   white-space: nowrap;
 }
 
-#philosopher-labels {
-  position: absolute;
-  left: 0;
-  right: 0;
-  top: 0;
-  height: 20px;
-  pointer-events: none;
-}
 
-.philosopher-label {
-  position: absolute;
-  top: 0;
-  transform: translateX(-50%);
-  font-size: 12px;
-  white-space: nowrap;
-}
 
 @media (min-width: 768px) {
   #topic-selector {

--- a/timeline/timeline.html
+++ b/timeline/timeline.html
@@ -58,7 +58,6 @@
       <div id="timeline-highlight"></div>
       <div id="timeline-tooltip"></div>
       <div id="timeline-ticks"></div>
-      <div id="philosopher-labels"></div>
     </div>
   </div>
   <script src="timeline.js"></script>

--- a/timeline/timeline.js
+++ b/timeline/timeline.js
@@ -469,9 +469,7 @@ function formatYear(year) {
 
 function initLabels() {
   const ticks = document.getElementById('timeline-ticks');
-  const labels = document.getElementById('philosopher-labels');
   ticks.innerHTML = '';
-  labels.innerHTML = '';
   const range = timelineEnd - timelineStart;
   const step = 500;
   let firstTick = Math.ceil(timelineStart / step) * step;
@@ -488,15 +486,6 @@ function initLabels() {
     ticks.appendChild(tick);
   }
 
-  philosophyTimeline.forEach(p => {
-    const label = document.createElement('div');
-    label.className = 'philosopher-label';
-    label.textContent = p.name;
-    const mid = (p.startYear + p.endYear) / 2;
-    const pos = ((mid - timelineStart) / range) * 100;
-    label.style.left = `${pos}%`;
-    labels.appendChild(label);
-  });
 }
 
 window.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## Summary
- remove philosopher label container from HTML
- drop label creation loop in `timeline.js`
- remove unused label styling

## Testing
- `node --check timeline/timeline.js`
- `npm test` *(fails: could not find `package.json`)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68595b6c90c883228bcdc3038ec71b4a