### PR TITLE
Fix ethics reconstruction info modal

### DIFF
--- a/argument-reconstruction/ethics.html
+++ b/argument-reconstruction/ethics.html
@@ -12,7 +12,7 @@
   </nav>
   <div class="container">
     <h1>Argument Reconstruction Activity</h1>
-    <button id="info-btn">Info</button>
+    <button id="open-info">Summary</button>
     <p>This activity lets you practice identifying premises and conclusions, distinguishing moral from nonmoral premises, and evaluating arguments. It follows Lewis Vaughn's guideline that moral arguments typically include at least one moral and one nonmoral premise.</p>
 
     <div id="reconstruction-game">
@@ -25,12 +25,6 @@
       <button id="reconstruction-next" class="hidden">Next</button>
     </div>
 
-      <section id="summary">
-        <h2>Summary</h2>
-        <p>This activity introduces several tools for evaluating arguments. A <strong>premise</strong> gives a reason to accept a <strong>conclusion</strong>, and moral arguments usually combine at least one moral premise with a nonmoral one.</p>
-        <p>A <strong>deductive</strong> argument aims for certainty—it is <em>valid</em> if the conclusion must be true whenever the premises are true and <em>sound</em> when those premises are in fact true. An <strong>inductive</strong> argument offers only probability; it is <em>strong</em> when the premises make the conclusion likely and <em>cogent</em> when those premises are also true.</p>
-        <p>Identifying hidden or missing premises helps clarify whether an argument succeeds according to these standards.</p>
-      </section>
 
   </div>
 

--- a/argument-reconstruction/ethics.js
+++ b/argument-reconstruction/ethics.js
@@ -197,12 +197,14 @@ document.getElementById("reconstruction-show").addEventListener("click", () => {
   document.getElementById("reconstruction-next").classList.remove("hidden");
 });
 
-document.addEventListener("DOMContentLoaded", startReconstruction);
-
-// Info modal logic
-document.getElementById("info-btn").addEventListener("click", () => {
-  document.getElementById("info-modal").classList.remove("hidden");
-});
-document.getElementById("close-info").addEventListener("click", () => {
-  document.getElementById("info-modal").classList.add("hidden");
+document.addEventListener("DOMContentLoaded", () => {
+  startReconstruction();
+  const open = document.getElementById("open-info");
+  const close = document.getElementById("close-info");
+  const modal = document.getElementById("info-modal");
+  if (open && close && modal) {
+    open.addEventListener("click", () => modal.classList.remove("hidden"));
+    close.addEventListener("click", () => modal.classList.add("hidden"));
+    modal.classList.remove("hidden");
+  }
 });


### PR DESCRIPTION
## Summary
- use the same `open-info` button as other reconstruction pages
- remove unused Summary section from ethics.html
- match intro & critical thinking JS behaviour on page load

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68595b6e887483229c4d780bb73d2510