### PR TITLE
Rename outline builder and expand example

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Additional pages include:
 - `chatbots/intro-philosophy-chat.html` – interactive chat with ancient Greek philosophers
 - `writing/citation.html` – identify citation mistakes
 - `writing/brainstorm.html` – build mind-map clusters for brainstorming
- - `writing/outlining.html` – outline builder for critiquing Kant's absolutism
+ - `writing/outlining.html` – outline builder for critiquing moral absolutism
 
 
 ## Project Structure

--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
         <div class="game-links">
           <a class="button" href="writing/citation.html">Citation Investigator</a>
           <a class="button" href="writing/brainstorm.html">Mind-Map Builder</a>
-          <a class="button" href="writing/outlining.html">Kant Outline Builder</a>
+          <a class="button" href="writing/outlining.html">Outline Builder</a>
         </div>
       </div>
     </div>

--- a/writing/index.html
+++ b/writing/index.html
@@ -15,7 +15,7 @@
     <div class="game-links">
       <button onclick="location.href='citation.html'">Citation Investigator</button>
       <button onclick="location.href='brainstorm.html'">Mind-Map Builder</button>
-      <button onclick="location.href='outlining.html'">Kant Outline Builder</button>
+      <button onclick="location.href='outlining.html'">Outline Builder</button>
     </div>
   </div>
 </body>

--- a/writing/outlining.html
+++ b/writing/outlining.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Kant Outline Builder</title>
+  <title>Outline Builder</title>
   <link rel="stylesheet" href="../jeopardy/style.css">
   <link rel="icon" href="../favicon.png" type="image/png">
   <style>
@@ -43,18 +43,13 @@
     <a id="home-link" href="../index.html">Thinker's Arcade</a>
   </nav>
   <div class="container">
-    <h1>Kant Outline Builder</h1>
+    <h1>Outline Builder</h1>
     <p class="instructions">Drag each piece into any order you wish. Use the blank lines to add your own explanation and support for each claim.</p>
     <ul id="puzzle-pieces"></ul>
     <ol id="outline-slots"></ol>
     <button id="example-btn">Show Example Outline</button>
     <div id="hint-text" class="hidden"></div>
     <div id="congrats" class="hidden"></div>
-    <section id="reflection" class="hidden">
-      <h2>Reflective Prompts</h2>
-      <p>How did arranging these puzzle pieces help you understand structuring philosophical arguments?</p>
-      <p>Explain why logical organization is essential for persuasive philosophical writing.</p>
-    </section>
     <p id="summary" class="hidden"><strong>Remember:</strong> Clear outlines guide readers step by step through your argument.</p>
   </div>
   <script src="outlining.js"></script>

--- a/writing/outlining.js
+++ b/writing/outlining.js
@@ -1,9 +1,29 @@
 const pieces = [
-  { text: 'Kant argues explicitly that moral rules must never admit exceptions, demonstrated clearly by his stance against lying even in extreme cases.', order: 0 },
-  { text: 'Moral decisions in real life often require flexibility and context sensitivity.', order: 1 },
-  { text: 'Rigid adherence to Kant\u2019s moral absolutism can lead to morally troubling outcomes, such as in Kant\u2019s famous Nazi-at-the-door scenario.', order: 2 },
-  { text: 'Ethical decision-making must sometimes prioritize consequences over absolute rules to truly be morally good.', order: 3 },
-  { text: 'Therefore, Kant\u2019s insistence on exceptionless moral rules is overly rigid and problematic.', order: 4 }
+  {
+    text: 'Kant argues explicitly that moral rules must never admit exceptions, demonstrated clearly by his stance against lying even in extreme cases.',
+    support: '(Kant, "On a Supposed Right to Lie from Philanthropy", 1797)',
+    order: 0
+  },
+  {
+    text: 'Moral decisions in real life often require flexibility and context sensitivity.',
+    support: 'W.D. Ross, "The Right and the Good" (1930)',
+    order: 1
+  },
+  {
+    text: 'Rigid adherence to Kant\u2019s moral absolutism can lead to morally troubling outcomes, such as in Kant\u2019s famous Nazi-at-the-door scenario.',
+    support: 'See Christine Korsgaard, "Creating the Kingdom of Ends" (1996)',
+    order: 2
+  },
+  {
+    text: 'Ethical decision-making must sometimes prioritize consequences over absolute rules to truly be morally good.',
+    support: 'J.S. Mill, "Utilitarianism" (1863)',
+    order: 3
+  },
+  {
+    text: 'Therefore, Kant\u2019s insistence on exceptionless moral rules is overly rigid and problematic.',
+    support: 'Balancing deontology with consequentialist concerns is recommended by many modern ethicists.',
+    order: 4
+  }
 ];
 
 
@@ -73,7 +93,6 @@ function checkComplete() {
   if (done) {
     document.getElementById('congrats').innerText = 'Outline complete!';
     document.getElementById('congrats').classList.remove('hidden');
-    document.getElementById('reflection').classList.remove('hidden');
     document.getElementById('summary').classList.remove('hidden');
   }
 }
@@ -83,7 +102,7 @@ function showExample() {
   list.innerHTML = pieces
     .slice()
     .sort((a, b) => a.order - b.order)
-    .map(p => `<li>${p.text}</li>`) 
+    .map(p => `<li>${p.text}<br><em>${p.support}</em></li>`)
     .join('');
   list.classList.remove('hidden');
 }


### PR DESCRIPTION
## Summary
- drop `Kant` from the outline builder name
- remove reflection prompts from the outline page
- show supporting references in the example outline
- update links and documentation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6859606c2f788322897eabea09b4db5b