### PR TITLE
Fix trolley scenario loop

### DIFF
--- a/trolley/trolley.html
+++ b/trolley/trolley.html
@@ -34,7 +34,6 @@
       <button id="next-btn">Next Scenario</button>
     </div>
     <div id="summary" class="hidden"></div>
-    <button id="ai-btn" class="hidden">AI Scenario</button>
   </div>
   <script src="trolley.js"></script>
 </body>

--- a/trolley/trolley.js
+++ b/trolley/trolley.js
@@ -62,7 +62,6 @@ const resultText = document.getElementById('result-text');
 const reflectionText = document.getElementById('reflection-question');
 const nextBtn = document.getElementById('next-btn');
 const summaryDiv = document.getElementById('summary');
-const aiBtn = document.getElementById('ai-btn');
 
 function showScenario() {
   const data = scenarios[currentIndex];
@@ -98,19 +97,14 @@ function showSummary() {
   summaryDiv.innerHTML =
     `<p>You chose the utilitarian option ${pullCount} time(s) and refused ${inactionCount} time(s).</p>` +
     `<p>Consequences matter, but ethics also involves principles, rights, and virtues beyond mere calculation.</p>`;
-  aiBtn.classList.remove('hidden');
 }
 
-function loadAIScenario() {
-  scenarios.push(aiScenario);
-  aiBtn.classList.add('hidden');
-  currentIndex = scenarios.length - 1;
-  showScenario();
-}
 
 actionBtn.addEventListener('click', () => handleChoice('action'));
 inactionBtn.addEventListener('click', () => handleChoice('inaction'));
 nextBtn.addEventListener('click', nextScenario);
-aiBtn.addEventListener('click', loadAIScenario);
 
-window.addEventListener('DOMContentLoaded', showScenario);
+window.addEventListener('DOMContentLoaded', () => {
+  scenarios.push(aiScenario);
+  showScenario();
+});


### PR DESCRIPTION
## Summary
- remove unused AI scenario button
- integrate the AI scenario into the initial scenario list
- stop showing the button at the end and push the scenario once when the game loads

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6859645ed03c8322bd77e4145a697d50