### PR TITLE
Update home layout and rename activities

### DIFF
--- a/argument-reconstruction/critical-thinking.html
+++ b/argument-reconstruction/critical-thinking.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Argument Reconstruction - Critical Thinking</title>
+  <title>Arguments - Critical Thinking</title>
   <link rel="stylesheet" href="../jeopardy/style.css">
   <link rel="icon" href="../favicon.png" type="image/png">
 </head>
@@ -11,7 +11,7 @@
     <a id="home-link" href="../index.html">Thinker's Arcade</a>
   </nav>
   <div class="container">
-    <h1>Argument Reconstruction Activity</h1>
+    <h1>Arguments Activity</h1>
     <p>Fill in the missing premises to strengthen each argument. Select the best option from the list.</p>
     <button id="open-info">Summary</button>
     <div id="reconstruction-game">

--- a/argument-reconstruction/ethics.html
+++ b/argument-reconstruction/ethics.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Argument Reconstruction - Ethics</title>
+  <title>Arguments - Ethics</title>
   <link rel="stylesheet" href="../jeopardy/style.css">
   <link rel="icon" href="../favicon.png" type="image/png">
 </head>
@@ -11,7 +11,7 @@
     <a id="home-link" href="../index.html">Thinker's Arcade</a>
   </nav>
   <div class="container">
-    <h1>Argument Reconstruction Activity</h1>
+    <h1>Arguments Activity</h1>
     <button id="open-info">Summary</button>
     <p>This activity lets you practice identifying premises and conclusions, distinguishing moral from nonmoral premises, and evaluating arguments. It follows Lewis Vaughn's guideline that moral arguments typically include at least one moral and one nonmoral premise.</p>
 

--- a/argument-reconstruction/intro-philosophy.html
+++ b/argument-reconstruction/intro-philosophy.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Argument Reconstruction - Intro to Philosophy</title>
+  <title>Arguments - Intro to Philosophy</title>
   <link rel="stylesheet" href="../jeopardy/style.css">
   <link rel="icon" href="../favicon.png" type="image/png">
 </head>
@@ -11,7 +11,7 @@
     <a id="home-link" href="../index.html">Thinker's Arcade</a>
   </nav>
   <div class="container">
-    <h1>Argument Reconstruction Activity</h1>
+    <h1>Arguments Activity</h1>
     <p>Identify premises, argument types, and evaluations for classic philosophy topics.</p>
     <button id="open-info">Summary</button>
     <div id="reconstruction-game">

--- a/home-review.js
+++ b/home-review.js
@@ -1,0 +1,19 @@
+// Toggle exam dropdowns on the homepage
+
+document.querySelectorAll('.review-btn').forEach(btn => {
+  const dropdown = btn.nextElementSibling;
+  btn.setAttribute('aria-expanded', 'false');
+  btn.addEventListener('click', (e) => {
+    e.preventDefault();
+    document.querySelectorAll('.exam-dropdown').forEach(dd => {
+      if (dd !== dropdown) {
+        dd.classList.add('hidden');
+        const b = dd.previousElementSibling;
+        if (b) b.setAttribute('aria-expanded', 'false');
+      }
+    });
+    dropdown.classList.toggle('hidden');
+    btn.setAttribute('aria-expanded', String(!dropdown.classList.contains('hidden')));
+  });
+});
+

--- a/index.html
+++ b/index.html
@@ -7,52 +7,62 @@
   <link rel="icon" href="favicon.png" type="image/png">
 </head>
 <body class="home">
-  <nav id="top-nav" aria-label="Main">
-    <a id="home-link" href="index.html">Thinkers' Arcade</a>
-  </nav>
+
 
   <main class="container home-container">
     <h1 id="home-title">Thinkers' Arcade</h1>
     <a href="index.html"><img id="site-icon" src="icon.png" alt="Thinkers' Arcade icon"></a>
-    <p id="instructions">Browse flashcards, trivia quizzes, argument reconstruction challenges, bonus games, and full review sets for every course.</p>
+    <p id="instructions">Browse flashcards, trivia quizzes, argument challenges, bonus games, and full review sets for every course.</p>
     <div id="topic-selector">
       <div class="course">
         <h3>Intro to Philosophy</h3>
         <div class="game-links">
-          <a class="button" href="jeopardy/index.html">Game Board</a>
           <a class="button" href="flashcards/flashcards.html?course=introPhilosophy">Flashcards</a>
           <a class="button" href="trivia/trivia.html?course=introPhilosophy">Trivia</a>
           <a class="button" href="chatbots/intro-philosophy-chat.html">Chat</a>
           <a class="button" href="timeline/timeline.html">Timeline</a>
-          <a class="button" href="argument-reconstruction/intro-philosophy.html">Reconstruction</a>
+          <a class="button" href="argument-reconstruction/intro-philosophy.html">Arguments</a>
+          <a class="button review-btn" href="#">Review Games</a>
+          <div class="exam-dropdown hidden">
+            <button onclick="location.href='jeopardy/index.html?topic=introPhilosophy&exam=Midterm'">Part 1</button>
+            <button onclick="location.href='jeopardy/index.html?topic=introPhilosophy&exam=Final'">Part 2</button>
+          </div>
         </div>
       </div>
       <div class="course">
         <h3>Critical Thinking</h3>
         <div class="game-links">
-          <a class="button" href="jeopardy/index.html">Game Board</a>
           <a class="button" href="flashcards/flashcards.html?course=criticalThinking">Flashcards</a>
           <a class="button" href="trivia/trivia.html?course=criticalThinking">Trivia</a>
           <a class="button" href="fallacy-detection/fallacy.html">Fallacy Detective</a>
-          <a class="button" href="argument-reconstruction/critical-thinking.html">Reconstruction</a>
+          <a class="button" href="argument-reconstruction/critical-thinking.html">Arguments</a>
+          <a class="button review-btn" href="#">Review Games</a>
+          <div class="exam-dropdown hidden">
+            <button onclick="location.href='jeopardy/index.html?topic=criticalThinking&exam=Midterm'">Part 1</button>
+            <button onclick="location.href='jeopardy/index.html?topic=criticalThinking&exam=Final'">Part 2</button>
+          </div>
         </div>
       </div>
       <div class="course">
         <h3>Ethics</h3>
         <div class="game-links">
-          <a class="button" href="jeopardy/index.html">Game Board</a>
           <a class="button" href="flashcards/flashcards.html?course=ethics">Flashcards</a>
           <a class="button" href="trivia/trivia.html?course=ethics">Trivia</a>
           <a class="button" href="chatbots/ethics-chat.html">Chat</a>
-          <a class="button" href="argument-reconstruction/ethics.html">Reconstruction</a>
+          <a class="button" href="argument-reconstruction/ethics.html">Arguments</a>
           <a class="button" href="trolley/trolley.html">Trolley Game</a>
+          <a class="button review-btn" href="#">Review Games</a>
+          <div class="exam-dropdown hidden">
+            <button onclick="location.href='jeopardy/index.html?topic=ethics&exam=Midterm'">Part 1</button>
+            <button onclick="location.href='jeopardy/index.html?topic=ethics&exam=Final'">Part 2</button>
+          </div>
         </div>
       </div>
       <div class="course">
         <h3>Writing in Philosophy</h3>
         <div class="game-links">
           <a class="button" href="writing/citation.html">Citation Investigator</a>
-          <a class="button" href="writing/brainstorm.html">Mind-Map Builder</a>
+          <a class="button" href="writing/brainstorm.html">Mind Mapping</a>
           <a class="button" href="writing/outlining.html">Outline Builder</a>
         </div>
       </div>
@@ -67,6 +77,7 @@
   </main>
 
   <footer class="site-footer">&copy; <a href="https://www.maparks.com">maxaeon</a> 2025</footer>
+  <script src="home-review.js"></script>
   <script src="jeopardy/who-said-it.js"></script>
 </body>
 </html>

--- a/jeopardy/inline-select.js
+++ b/jeopardy/inline-select.js
@@ -142,3 +142,11 @@ document.addEventListener('visibilitychange', () => {
   }
 });
 window.addEventListener('beforeunload', goHome);
+
+// Auto-open the appropriate exam if parameters are provided in the URL
+const startParams = new URLSearchParams(window.location.search);
+const startTopic = startParams.get('topic');
+const startExam = startParams.get('exam');
+if (startTopic && startExam) {
+  showModeModal(startTopic, startExam);
+}

--- a/writing/brainstorm.html
+++ b/writing/brainstorm.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Philosophical Mind-Map Builder</title>
+  <title>Philosophical Mind Mapping</title>
   <link rel="stylesheet" href="../jeopardy/style.css">
   <link rel="icon" href="../favicon.png" type="image/png">
   <style>
@@ -31,7 +31,7 @@
     <a id="home-link" href="../index.html">Thinker's Arcade</a>
   </nav>
   <div class="container">
-    <h1>Philosophical Mind-Map Builder</h1>
+    <h1>Philosophical Mind Mapping</h1>
     <p class="instructions">Drag and drop the concepts below into logical clusters to brainstorm arguments against exceptionless moral rules.</p>
     <ul id="concept-pool"></ul>
     <div id="clusters">

--- a/writing/index.html
+++ b/writing/index.html
@@ -14,7 +14,7 @@
     <h1>Writing Games</h1>
     <div class="game-links">
       <button onclick="location.href='citation.html'">Citation Investigator</button>
-      <button onclick="location.href='brainstorm.html'">Mind-Map Builder</button>
+      <button onclick="location.href='brainstorm.html'">Mind Mapping</button>
       <button onclick="location.href='outlining.html'">Outline Builder</button>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- remove top navigation link on homepage
- add review game dropdowns for each course
- rename argument reconstruction to arguments
- rename mind map builder to mind mapping
- support exam query parameters on game board page

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6859658757748322905b118a038ae253