### PR TITLE
Add Debate Duel activity

### DIFF
--- a/debate-duel/debate-duel.html
+++ b/debate-duel/debate-duel.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Debate Duel</title>
+  <link rel="stylesheet" href="../jeopardy/style.css">
+  <link rel="icon" href="../favicon.png" type="image/png">
+</head>
+<body>
+  <nav id="top-nav">
+    <a id="home-link" href="../index.html">Thinker's Arcade</a>
+  </nav>
+  <div class="container">
+    <div id="intro">
+      <h1>Debate Duel</h1>
+      <p>Welcome to Debate Duel! In this interactive simulation, you'll practice critical thinking skills by engaging in structured debates. You'll choose responses, evaluate arguments, and avoid logical fallacies to out-debate your virtual opponent.</p>
+      <button id="start-btn">Start</button>
+    </div>
+    <div id="topic-select" class="hidden">
+      <h2>Select a Topic</h2>
+      <div class="game-links">
+        <button class="topic-btn" data-topic="A">Topic A: Should social media platforms regulate misinformation?</button>
+        <button class="topic-btn" data-topic="B">Topic B: Is artificial intelligence beneficial or dangerous?</button>
+        <button class="topic-btn" data-topic="C">Topic C: Should animal testing be banned in all circumstances?</button>
+        <button class="topic-btn" data-topic="D">Topic D: Should college education be tuition-free?</button>
+      </div>
+    </div>
+    <div id="debate" class="hidden">
+      <h2 id="debate-title"></h2>
+      <p id="opponent"></p>
+      <div id="responses" class="mc-options"></div>
+      <p id="feedback" class="hidden"></p>
+      <button id="next-round" class="hidden">Next</button>
+    </div>
+    <div id="summary" class="hidden">
+      <h2>Debate Completed!</h2>
+      <p id="summary-text"></p>
+      <section id="reflection">
+        <p>Which argument or response was the most challenging for you, and why?</p>
+        <textarea rows="3" style="width:90%;"></textarea>
+        <p>Did identifying logical fallacies help you improve your critical thinking? How?</p>
+        <textarea rows="3" style="width:90%;"></textarea>
+        <p>Describe a strategy you used successfully to construct strong, logical arguments.</p>
+        <textarea rows="3" style="width:90%;"></textarea>
+      </section>
+    </div>
+  </div>
+  <script src="debate-duel.js"></script>
+</body>
+</html>

--- a/debate-duel/debate-duel.js
+++ b/debate-duel/debate-duel.js
@@ -1,0 +1,154 @@
+const topics = {
+  A: {
+    title: "Should social media platforms regulate misinformation?",
+    rounds: [
+      {
+        opponent: "Social media should never regulate misinformation because doing so violates free speech and opens the door to censorship.",
+        options: [
+          { text: "Protecting free speech is important, but allowing harmful misinformation like dangerous medical falsehoods can directly harm public health.", type: "strong", feedback: "Strong response! You've balanced free speech considerations with evidence of potential harm." },
+          { text: "You're wrong—regulation is always needed because people lie.", type: "weak", feedback: "Weak response: Your claim lacks clarity and evidence." },
+          { text: "So you're saying you support people lying and causing harm?", type: "fallacious", feedback: "Fallacious response: You've used a logical fallacy (strawman)—misrepresenting your opponent’s argument." }
+        ]
+      },
+      {
+        opponent: "But if we allow regulation, who decides what counts as misinformation? It risks becoming subjective and biased.",
+        options: [
+          { text: "You raise a valid concern about bias, which is why transparent guidelines and independent fact-checking standards are necessary.", type: "strong", feedback: "Strong response! You addressed the bias concern and proposed safeguards." },
+          { text: "Bias happens anyway, so we shouldn't worry too much.", type: "weak", feedback: "Weak response: This dismissal doesn't address the bias problem." },
+          { text: "If we don't regulate misinformation, society will completely collapse.", type: "fallacious", feedback: "Fallacious response: That's a slippery slope fallacy." }
+        ]
+      }
+    ]
+  },
+  B: {
+    title: "Is artificial intelligence beneficial or dangerous?",
+    rounds: [
+      {
+        opponent: "AI is beneficial; it automates tedious tasks and enhances productivity.",
+        options: [
+          { text: "AI indeed provides benefits, but ignoring potential harms like job loss and biases can be dangerous. Balance is key.", type: "strong", feedback: "Strong response! You acknowledged benefits while highlighting potential harms." },
+          { text: "AI just takes away jobs; it’s bad.", type: "weak", feedback: "Weak response: It's vague and lacks supporting reasoning." },
+          { text: "Either AI saves the world or destroys humanity—there’s no middle ground.", type: "fallacious", feedback: "Fallacious response: This presents a false dilemma." }
+        ]
+      },
+      {
+        opponent: "But focusing on potential dangers could slow down innovation and economic growth.",
+        options: [
+          { text: "True, but responsible development explicitly addresses risks while still allowing progress.", type: "strong", feedback: "Strong response! You advocate balanced progress with risk management." },
+          { text: "Innovation matters more than anything.", type: "weak", feedback: "Weak response: This overlooks valid safety concerns." },
+          { text: "If we allow AI, it will inevitably wipe out humanity.", type: "fallacious", feedback: "Fallacious response: This is a slippery slope to extinction." }
+        ]
+      }
+    ]
+  },
+  C: {
+    title: "Should animal testing be banned in all circumstances?",
+    rounds: [
+      {
+        opponent: "Animal testing helps save human lives by enabling vital medical advances.",
+        options: [
+          { text: "Medical advances are important, but reducing unnecessary suffering by seeking alternatives wherever possible should be our goal.", type: "strong", feedback: "Strong response! You acknowledged benefits while proposing humane alternatives." },
+          { text: "Animal testing is cruel, end of story.", type: "weak", feedback: "Weak response: This ignores the reasoning about medical advances." },
+          { text: "Anyone supporting animal testing explicitly enjoys animal cruelty.", type: "fallacious", feedback: "Fallacious response: That's an appeal to emotion." }
+        ]
+      },
+      {
+        opponent: "Completely banning it could halt progress on lifesaving treatments.",
+        options: [
+          { text: "That's why many advocate tighter regulation and investment in alternatives rather than an outright ban.", type: "strong", feedback: "Strong response! You provide a balanced compromise." },
+          { text: "Progress will happen anyway.", type: "weak", feedback: "Weak response: This doesn't address the issue." },
+          { text: "If we ban testing, humanity will never cure diseases again.", type: "fallacious", feedback: "Fallacious response: That's a slippery slope." }
+        ]
+      }
+    ]
+  },
+  D: {
+    title: "Should college education be tuition-free?",
+    rounds: [
+      {
+        opponent: "Tuition-free college places an unfair tax burden on people who don’t benefit from higher education.",
+        options: [
+          { text: "Your fairness concern is important, but investing in education benefits society through better employment, lower crime rates, and economic growth.", type: "strong", feedback: "Strong response! You address fairness while explaining societal benefits." },
+          { text: "Everyone should just pay taxes anyway; who cares?", type: "weak", feedback: "Weak response: This ignores the fairness objection." },
+          { text: "Only selfish people oppose tuition-free education.", type: "fallacious", feedback: "Fallacious response: That's an ad hominem." }
+        ]
+      },
+      {
+        opponent: "But how would we fund it without cutting other essential programs?",
+        options: [
+          { text: "We could explore a mix of progressive taxes and cost-sharing plans while carefully evaluating spending priorities.", type: "strong", feedback: "Strong response! You proposed constructive funding options." },
+          { text: "Funding isn't a big deal; money will appear.", type: "weak", feedback: "Weak response: This doesn't provide a realistic solution." },
+          { text: "If we don't make college free, the economy will collapse.", type: "fallacious", feedback: "Fallacious response: That's an exaggerated slippery slope." }
+        ]
+      }
+    ]
+  }
+};
+
+let currentTopic = null;
+let roundIndex = 0;
+const counts = { strong: 0, weak: 0, fallacious: 0 };
+
+function showTopics() {
+  document.getElementById('intro').classList.add('hidden');
+  document.getElementById('topic-select').classList.remove('hidden');
+}
+
+function startTopic(key) {
+  currentTopic = topics[key];
+  roundIndex = 0;
+  counts.strong = counts.weak = counts.fallacious = 0;
+  document.getElementById('topic-select').classList.add('hidden');
+  document.getElementById('debate-title').innerText = currentTopic.title;
+  document.getElementById('debate').classList.remove('hidden');
+  showRound();
+}
+
+function showRound() {
+  const round = currentTopic.rounds[roundIndex];
+  document.getElementById('opponent').innerText = round.opponent;
+  const respDiv = document.getElementById('responses');
+  respDiv.innerHTML = '';
+  round.options.forEach(opt => {
+    const btn = document.createElement('button');
+    btn.className = 'option-btn';
+    btn.innerText = opt.text;
+    btn.onclick = () => chooseResponse(opt);
+    respDiv.appendChild(btn);
+  });
+  document.getElementById('feedback').classList.add('hidden');
+  document.getElementById('next-round').classList.add('hidden');
+}
+
+function chooseResponse(option) {
+  counts[option.type]++;
+  const fb = document.getElementById('feedback');
+  fb.innerText = option.feedback;
+  fb.style.color = option.type === 'strong' ? '#4caf50' : option.type === 'weak' ? '#ff9800' : '#c62828';
+  fb.classList.remove('hidden');
+  document.getElementById('next-round').classList.remove('hidden');
+}
+
+function nextRound() {
+  roundIndex++;
+  if (roundIndex < currentTopic.rounds.length) {
+    showRound();
+  } else {
+    showSummary();
+  }
+}
+
+function showSummary() {
+  document.getElementById('debate').classList.add('hidden');
+  const text = `You chose strong arguments: ${counts.strong}/2\n` +
+               `You chose weak arguments: ${counts.weak}/2\n` +
+               `Logical fallacies used: ${counts.fallacious}`;
+  document.getElementById('summary-text').innerText = text;
+  document.getElementById('summary').classList.remove('hidden');
+}
+
+document.getElementById('start-btn').addEventListener('click', showTopics);
+document.querySelectorAll('.topic-btn').forEach(btn => {
+  btn.addEventListener('click', () => startTopic(btn.dataset.topic));
+});
+document.getElementById('next-round').addEventListener('click', nextRound);

--- a/index.html
+++ b/index.html
@@ -36,6 +36,7 @@
           <a class="button" href="trivia/trivia.html?course=criticalThinking">Trivia</a>
           <a class="button" href="fallacy-detection/fallacy.html">Fallacy Detective</a>
           <a class="button" href="argument-reconstruction/critical-thinking.html">Arguments</a>
+          <a class="button" href="debate-duel/debate-duel.html">Debate Duel</a>
           <a class="button review-btn" href="#">Review Games</a>
           <div class="exam-dropdown hidden">
             <button onclick="location.href='jeopardy/index.html?topic=criticalThinking&exam=Midterm'">Part 1</button>


### PR DESCRIPTION
## Summary
- add new **Debate Duel** activity with interactive debate rounds
- link Debate Duel from Critical Thinking section of the homepage

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68596dedafec8322b860fb6bca61b62a