### PR TITLE
Add course progress bars on homepage

### DIFF
--- a/home-review.js
+++ b/home-review.js
@@ -17,3 +17,17 @@ document.querySelectorAll('.review-btn').forEach(btn => {
   });
 });
 
+// Update homepage course progress bars from localStorage
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('.course').forEach(course => {
+    const key = course.dataset.course;
+    const bar = course.querySelector('.course-progress-bar');
+    if (!key || !bar) return;
+    const value = parseInt(localStorage.getItem(`progress-${key}`) || '0', 10);
+    if (!isNaN(value)) {
+      const pct = Math.min(Math.max(value, 0), 100);
+      bar.style.width = pct + '%';
+    }
+  });
+});
+

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
   <main class="container home-container">
     <p id="instructions">Browse flashcards, trivia quizzes, argument challenges, bonus games, and full review sets for every course.</p>
     <div id="topic-selector">
-      <div class="course">
+      <div class="course" data-course="introPhilosophy">
         <h3>Intro to Philosophy</h3>
         <div class="game-links">
           <a class="button" href="flashcards/flashcards.html?course=introPhilosophy">Flashcards</a>
@@ -31,8 +31,9 @@
             <button onclick="location.href='jeopardy/index.html?topic=introPhilosophy&exam=Final'">Part 2</button>
           </div>
         </div>
+        <div class="course-progress"><div class="course-progress-bar"></div></div>
       </div>
-      <div class="course">
+      <div class="course" data-course="criticalThinking">
         <h3>Critical Thinking</h3>
         <div class="game-links">
           <a class="button" href="flashcards/flashcards.html?course=criticalThinking">Flashcards</a>
@@ -46,8 +47,9 @@
             <button onclick="location.href='jeopardy/index.html?topic=criticalThinking&exam=Final'">Part 2</button>
           </div>
         </div>
+        <div class="course-progress"><div class="course-progress-bar"></div></div>
       </div>
-      <div class="course">
+      <div class="course" data-course="ethics">
         <h3>Ethics</h3>
         <div class="game-links">
           <a class="button" href="flashcards/flashcards.html?course=ethics">Flashcards</a>
@@ -61,8 +63,9 @@
             <button onclick="location.href='jeopardy/index.html?topic=ethics&exam=Final'">Part 2</button>
           </div>
         </div>
+        <div class="course-progress"><div class="course-progress-bar"></div></div>
       </div>
-      <div class="course">
+      <div class="course" data-course="writing">
         <h3>Writing in Philosophy</h3>
         <div class="game-links">
           <a class="button" href="writing/citation.html">Citation Investigator</a>
@@ -70,6 +73,7 @@
           <a class="button" href="writing/outlining.html">Outline Builder</a>
           <a class="button" href="writing/thesis-evaluation.html">Thesis Evaluation</a>
         </div>
+        <div class="course-progress"><div class="course-progress-bar"></div></div>
       </div>
     </div>
     <div id="quote-sidebar" class="quote-open">

--- a/jeopardy/style.css
+++ b/jeopardy/style.css
@@ -80,6 +80,7 @@ body.home #site-icon {
   margin-top: 10px;
   margin-bottom: 0;
   font-size: 32px;
+  text-align: center;
 }
 
 #home-header {
@@ -316,6 +317,22 @@ button {
   transition: width 0.3s ease;
 }
 
+.course-progress {
+  height: 8px;
+  background-color: #333;
+  width: 100%;
+  margin-top: 8px;
+  border-radius: 4px;
+}
+
+.course-progress-bar {
+  height: 100%;
+  background-color: #4caf50;
+  width: 0;
+  border-radius: 4px;
+  transition: width 0.3s ease;
+}
+
 #quote-sidebar {
   position: fixed;
   right: 0;
@@ -433,6 +450,10 @@ button {
   }
 
   #progress {
+    height: 6px;
+  }
+
+  .course-progress {
     height: 6px;
   }
 


### PR DESCRIPTION
## Summary
- center "Thinkers' Arcade" heading
- add per-course progress bar markup
- style `.course-progress` and `.course-progress-bar`
- read progress values from `localStorage`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68597277d8248322be5b78f1b368e50f