### PR TITLE
Add interactive editing for Mind Map

### DIFF
--- a/writing/brainstorm.html
+++ b/writing/brainstorm.html
@@ -14,6 +14,28 @@
       margin:4px;
       border-radius:6px;
       cursor:grab;
+      position:relative;
+    }
+    #concept-pool li button.delete {
+      position:absolute;
+      top:-6px;
+      right:-6px;
+      background:#f44336;
+      border:none;
+      color:#fff;
+      border-radius:50%;
+      width:16px;
+      height:16px;
+      font-size:12px;
+      cursor:pointer;
+    }
+    #node-controls {
+      margin-bottom:10px;
+    }
+    #node-controls input[type="text"] {
+      padding:4px 6px;
+      border-radius:4px;
+      margin-right:6px;
     }
     .cluster {
       border:2px dashed #7b1fa2;
@@ -23,7 +45,29 @@
       border-radius:8px;
     }
     .cluster ul { list-style:none; padding:0; }
-    .cluster li { background:#ba68c8; color:#000; margin:4px; padding:4px 6px; border-radius:4px; cursor:grab; display:inline-block; }
+    .cluster li {
+      background:#ba68c8;
+      color:#000;
+      margin:4px;
+      padding:4px 6px;
+      border-radius:4px;
+      cursor:grab;
+      display:inline-block;
+      position:relative;
+    }
+    .cluster li button.delete {
+      position:absolute;
+      top:-6px;
+      right:-6px;
+      background:#f44336;
+      border:none;
+      color:#fff;
+      border-radius:50%;
+      width:16px;
+      height:16px;
+      font-size:12px;
+      cursor:pointer;
+    }
   </style>
 </head>
 <body>
@@ -33,6 +77,11 @@
   <div class="container">
     <h1>Philosophical Mind Mapping</h1>
     <p class="instructions">Drag and drop the concepts below into logical clusters to brainstorm arguments against exceptionless moral rules.</p>
+    <div id="node-controls">
+      <input type="text" id="new-node-text" placeholder="Concept text">
+      <input type="color" id="node-color" value="#ce93d8">
+      <button id="add-node">Add Node</button>
+    </div>
     <ul id="concept-pool"></ul>
     <div id="clusters">
       <div class="cluster drop-zone"><h3>Cluster 1</h3><ul></ul></div>
@@ -55,11 +104,13 @@
         <div class="cluster"><h3>Cluster 3</h3><ul contenteditable="true"></ul></div>
       </div>
       <button id="export-mindmap">Export as PNG</button>
+      <button id="export-pdf">Export as PDF</button>
       <button id="reset-mindmap">Reset</button>
     </div>
   </div>
   <script src="brainstorm.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/canvas-to-image@1.0.4/dist/canvas-to-image.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
 </body>
 </html>

--- a/writing/brainstorm.js
+++ b/writing/brainstorm.js
@@ -1,4 +1,4 @@
-const concepts = [
+const defaultConcepts = [
   'Moral Dilemmas (where rules conflict)',
   'Nazi-at-the-door scenario (Kant)',
   'Doctrine of double effect (Aquinas)',
@@ -15,30 +15,67 @@ const concepts = [
   'Intention vs. Outcome'
 ];
 
-function buildPool() {
+function createNode(text, color = '#ce93d8') {
+  const li = document.createElement('li');
+  li.className = 'node';
+  li.id = 'node-' + Math.random().toString(36).slice(2, 9);
+  li.draggable = true;
+  li.style.backgroundColor = color;
+  li.dataset.color = color;
+  li.innerHTML = `<span class="label">${text}</span><button class="delete">&times;</button>`;
+  li.addEventListener('dragstart', e => {
+    e.dataTransfer.setData('text/plain', li.id);
+  });
+  li.querySelector('.delete').addEventListener('click', e => {
+    e.stopPropagation();
+    li.remove();
+  });
+  li.addEventListener('dblclick', () => editNode(li));
+  return li;
+}
+
+function addNode(text, color) {
   const pool = document.getElementById('concept-pool');
-  concepts.forEach((text, idx) => {
-    const li = document.createElement('li');
-    li.innerText = text;
-    li.id = 'concept-' + idx;
-    li.draggable = true;
-    li.addEventListener('dragstart', e => {
-      e.dataTransfer.setData('text/plain', li.id);
-    });
-    pool.appendChild(li);
+  pool.appendChild(createNode(text, color));
+}
+
+function addNodeFromInput() {
+  const txt = document.getElementById('new-node-text');
+  const color = document.getElementById('node-color').value;
+  if (txt.value.trim()) {
+    addNode(txt.value.trim(), color);
+    txt.value = '';
+  }
+}
+
+function editNode(li) {
+  const label = li.querySelector('.label');
+  const newText = prompt('Edit text', label.innerText);
+  if (newText !== null) label.innerText = newText;
+  const newColor = prompt('Enter color', li.dataset.color);
+  if (newColor !== null) {
+    li.style.backgroundColor = newColor;
+    li.dataset.color = newColor;
+  }
+}
+
+function makeDroppable(container) {
+  container.addEventListener('dragover', e => e.preventDefault());
+  container.addEventListener('drop', e => {
+    e.preventDefault();
+    const id = e.dataTransfer.getData('text/plain');
+    const item = document.getElementById(id);
+    if (item) container.appendChild(item);
   });
 }
 
+function buildPool() {
+  defaultConcepts.forEach(text => addNode(text, '#ce93d8'));
+}
+
 function enableDrops() {
-  document.querySelectorAll('.drop-zone').forEach(zone => {
-    zone.addEventListener('dragover', e => e.preventDefault());
-    zone.addEventListener('drop', e => {
-      e.preventDefault();
-      const id = e.dataTransfer.getData('text/plain');
-      const item = document.getElementById(id);
-      if (item) zone.querySelector('ul').appendChild(item);
-    });
-  });
+  makeDroppable(document.getElementById('concept-pool'));
+  document.querySelectorAll('.drop-zone ul, #mindmap .cluster ul').forEach(makeDroppable);
 }
 
 document.getElementById('show-suggested').addEventListener('click', () => {
@@ -67,6 +104,7 @@ document.getElementById('show-suggested').addEventListener('click', () => {
 window.addEventListener('DOMContentLoaded', () => {
   buildPool();
   enableDrops();
+  document.getElementById('add-node').addEventListener('click', addNodeFromInput);
 });
 
 // Project mode
@@ -85,5 +123,20 @@ function exportMindMap() {
   });
 }
 
+function exportMindMapPDF() {
+  const area = document.getElementById('mindmap');
+  html2canvas(area).then(canvas => {
+    const imgData = canvas.toDataURL('image/png');
+    const { jsPDF } = window.jspdf;
+    const pdf = new jsPDF({ orientation: 'landscape' });
+    const imgProps = pdf.getImageProperties(imgData);
+    const pdfWidth = pdf.internal.pageSize.getWidth();
+    const pdfHeight = (imgProps.height * pdfWidth) / imgProps.width;
+    pdf.addImage(imgData, 'PNG', 0, 0, pdfWidth, pdfHeight);
+    pdf.save('mindmap.pdf');
+  });
+}
+
 document.getElementById('reset-mindmap').addEventListener('click', resetMindMap);
 document.getElementById('export-mindmap').addEventListener('click', exportMindMap);
+document.getElementById('export-pdf').addEventListener('click', exportMindMapPDF);


### PR DESCRIPTION
## Summary
- add controls for creating and editing mind-map nodes
- support node deletion, color editing and drag/drop anywhere
- allow exporting the project mind map as PNG or PDF

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_685976ee38f8832286c7aee068569bc7