### PR TITLE
Add customizable thesis prompts and export options

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This repository contains a set of lightweight browser games that let you review 
 - "Who Said It?" quote quiz
 - Ethics Chat page with rotating philosopher perspectives
 - Intro Philosophy Chat covering ancient Greek thinkers
-- Writing games now include a "Start Your Own Project" mode with templates that can be exported as PDF, DOCX, or PNG
+- Writing games now include a "Start Your Own Project" mode with templates that can be exported as PDF, DOCX, or PNG. Thesis prompts are editable and you can export just the thesis or a combined document with your answers.
 
 ## Getting Started
 

--- a/writing/thesis-evaluation.html
+++ b/writing/thesis-evaluation.html
@@ -28,11 +28,31 @@
       <h2>Reflective Prompts</h2>
       <p>How did the feedback change your approach? What remains unclear in your argument?</p>
     </section>
+
+    <section id="thesis-questions">
+      <h2>Thesis Builder</h2>
+      <div id="questions">
+        <div class="prompt">
+          <label contenteditable="true">What main idea are you arguing?</label>
+          <textarea rows="2" class="answer" style="width:90%;"></textarea>
+        </div>
+        <div class="prompt">
+          <label contenteditable="true">Why is this important?</label>
+          <textarea rows="2" class="answer" style="width:90%;"></textarea>
+        </div>
+        <div class="prompt">
+          <label contenteditable="true">How can you summarize your point?</label>
+          <textarea rows="2" class="answer" style="width:90%;"></textarea>
+        </div>
+      </div>
+      <button id="add-prompt">Add Prompt</button>
+    </section>
     <button id="start-project">Start Your Own Project</button>
     <div id="project-area" class="project-area hidden">
       <h2>Thesis Workspace</h2>
       <textarea id="project-thesis" rows="4" style="width:90%;"></textarea><br>
-      <button id="export-thesis">Export as DOCX</button>
+      <button id="export-thesis">Export Thesis Only</button>
+      <button id="export-all">Export All</button>
       <button id="reset-thesis">Reset</button>
     </div>
   </div>

--- a/writing/thesis-evaluation.js
+++ b/writing/thesis-evaluation.js
@@ -84,3 +84,43 @@ document.getElementById('export-thesis').addEventListener('click', () => {
     URL.revokeObjectURL(url);
   });
 });
+
+function addPrompt(text = 'New prompt') {
+  const container = document.getElementById('questions');
+  const div = document.createElement('div');
+  div.className = 'prompt';
+  const label = document.createElement('label');
+  label.contentEditable = 'true';
+  label.innerText = text;
+  const ta = document.createElement('textarea');
+  ta.rows = 2;
+  ta.className = 'answer';
+  ta.style.width = '90%';
+  div.append(label, document.createElement('br'), ta);
+  container.appendChild(div);
+}
+
+document.getElementById('add-prompt').addEventListener('click', () => {
+  const text = prompt('Enter a new prompt question:');
+  if (text) addPrompt(text);
+});
+
+document.getElementById('export-all').addEventListener('click', () => {
+  const { Document, Packer, Paragraph } = window.docx;
+  const doc = new Document();
+  const children = [new Paragraph(document.getElementById('project-thesis').value)];
+  document.querySelectorAll('#questions .prompt').forEach(p => {
+    const q = p.querySelector('label').innerText.trim();
+    const a = p.querySelector('textarea').value.trim();
+    children.push(new Paragraph(`${q} ${a}`));
+  });
+  doc.addSection({ children });
+  Packer.toBlob(doc).then(blob => {
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'thesis-with-notes.docx';
+    a.click();
+    URL.revokeObjectURL(url);
+  });
+});


### PR DESCRIPTION
## Summary
- make thesis prompts editable and allow adding new questions
- enable exporting just the thesis or the thesis with prompt answers
- document new thesis export features

## Testing
- `npm test` *(fails: ENOENT: no such file or directory)*
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68597719f5a88322baa540fc18d46f57