### PR TITLE
Add placeholder flashcard overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,17 @@ Additional pages include:
 - **chatbots/** – lightweight chat pages
 - **writing/** – short activities for philosophical writing practice
 
+### Custom Flashcard Sets
+
+Two optional data files in `jeopardy/data` let you override the built-in
+question banks with your own flashcards:
+
+- `intro-philosophy-flashcards.js` – defines `window.introPhilosophyFlashcards`
+- `critical-thinking-flashcards.js` – defines `window.criticalThinkingFlashcards`
+
+If present, these objects are used by the Flashcards and Trivia pages in place
+of the bundled exam questions.
+
 ## Contributing
 
 Issues and pull requests are welcome.

--- a/flashcards/flashcards.html
+++ b/flashcards/flashcards.html
@@ -41,6 +41,8 @@
   <script src="../jeopardy/data/critical-thinking-final.js"></script>
   <script src="../jeopardy/data/intro-philosophy.js"></script>
   <script src="../jeopardy/data/intro-philosophy-final.js"></script>
+  <script src="../jeopardy/data/intro-philosophy-flashcards.js"></script>
+  <script src="../jeopardy/data/critical-thinking-flashcards.js"></script>
   <script src="../jeopardy/data/ethics-flashcards.js"></script>
   <script src="flashcards.js"></script>
 </body>

--- a/jeopardy/data/critical-thinking-flashcards.js
+++ b/jeopardy/data/critical-thinking-flashcards.js
@@ -1,0 +1,3 @@
+// Critical Thinking flashcards
+// TODO: populate with chapter-aligned terms and definitions supplied by the user
+window.criticalThinkingFlashcards = {};

--- a/jeopardy/data/intro-philosophy-flashcards.js
+++ b/jeopardy/data/intro-philosophy-flashcards.js
@@ -1,0 +1,3 @@
+// Intro to Philosophy flashcards
+// TODO: populate with chapter-aligned terms and definitions supplied by the user
+window.introPhilosophyFlashcards = {};

--- a/trivia/trivia.html
+++ b/trivia/trivia.html
@@ -37,6 +37,8 @@
   <script src="../jeopardy/data/critical-thinking-final.js"></script>
   <script src="../jeopardy/data/intro-philosophy.js"></script>
   <script src="../jeopardy/data/intro-philosophy-final.js"></script>
+  <script src="../jeopardy/data/intro-philosophy-flashcards.js"></script>
+  <script src="../jeopardy/data/critical-thinking-flashcards.js"></script>
   <script src="../jeopardy/data/ethics-flashcards.js"></script>
   <script src="flashcards.js"></script>
   <script src="trivia.js"></script>


### PR DESCRIPTION
## Summary
- add new `critical-thinking-flashcards.js` and `intro-philosophy-flashcards.js` placeholder datasets
- load the placeholder files in the flashcards and trivia pages
- document the custom flashcard files in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68598c086b688322aaac825e27742dfe