### PR TITLE
Fix timeline year label

### DIFF
--- a/timeline/timeline.js
+++ b/timeline/timeline.js
@@ -490,8 +490,8 @@ function initTimelineHover() {
 }
 
 function formatYear(year) {
-  if (year >= 1) {
-    return year - 1; // adjust for missing year zero
+  if (year > 0) {
+    return year;
   }
   if (year === 0) {
     return 1;


### PR DESCRIPTION
## Summary
- correct off-by-one error in timeline year labeling

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68598f0b97ec8322a0c9aee8d804430f