### PR TITLE
Ensure review games link is placed on third row

### DIFF
--- a/jeopardy/style.css
+++ b/jeopardy/style.css
@@ -171,6 +171,19 @@ body.home {
   justify-content: center;
 }
 
+/* On the homepage, arrange links in three columns and force the
+   "Review Games" button to appear on its own third row */
+body.home .game-links {
+  display: grid;
+  grid-template-columns: repeat(3, auto);
+  justify-content: center;
+}
+
+body.home .game-links .review-btn {
+  grid-column: 1 / -1;
+  grid-row: 3;
+}
+
 .course h3 {
   margin-bottom: 4px;
 }


### PR DESCRIPTION
## Summary
- arrange home page game links in a grid layout
- force the Review Games link onto its own third row

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest` *(fails: no tests collected)*

------
https://chatgpt.com/codex/tasks/task_e_6859951f4dac8322a085f3cc570fb35c