### PR TITLE
Fix button wrapping in course links

### DIFF
--- a/jeopardy/style.css
+++ b/jeopardy/style.css
@@ -143,7 +143,7 @@ body.home {
   padding: 20px;
   border-radius: 12px;
   width: 100%;
-  max-width: 400px;
+  max-width: 520px;
 }
 
 .exam-dropdown {


### PR DESCRIPTION
## Summary
- expand course card width so game links don't wrap

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6859990691348322bdddbbf8a989c56e