### PR TITLE
Add keyboard navigation and ARIA roles

### DIFF
--- a/flashcards/flashcards.html
+++ b/flashcards/flashcards.html
@@ -26,7 +26,7 @@
       </select>
     </div>
 
-    <div id="flashcard" class="hidden" hidden>
+    <div id="flashcard" class="hidden" hidden tabindex="0">
       <p id="flashcard-question"></p>
       <p id="flashcard-answer" class="hidden" hidden></p>
       <button id="show-answer">Show Answer</button>

--- a/flashcards/flashcards.js
+++ b/flashcards/flashcards.js
@@ -95,6 +95,12 @@ function nextCard() {
   loadCard();
 }
 
+function prevCard() {
+  if (!currentCards.length) return;
+  cardIndex = (cardIndex - 1 + currentCards.length) % currentCards.length;
+  loadCard();
+}
+
 function exportCards() {
   if (!currentCards.length) return;
   const format = prompt('Export as json or csv?', 'json');
@@ -144,6 +150,19 @@ document.getElementById('show-answer').addEventListener('click', showAnswer);
 document.getElementById('next-card').addEventListener('click', nextCard);
 document.getElementById('export-cards').addEventListener('click', exportCards);
 document.getElementById('quiz-mode').addEventListener('click', startQuiz);
+
+// Keyboard navigation
+document.addEventListener('keydown', (e) => {
+  const flashcard = document.getElementById('flashcard');
+  if (flashcard.classList.contains('hidden')) return;
+  if (e.key === 'ArrowRight') {
+    nextCard();
+  } else if (e.key === 'ArrowLeft') {
+    prevCard();
+  } else if (e.key === 'ArrowDown') {
+    showAnswer();
+  }
+});
 
 function getParam(name) {
   const params = new URLSearchParams(window.location.search);

--- a/jeopardy/index.html
+++ b/jeopardy/index.html
@@ -73,7 +73,7 @@
     <div id="scoreboard" class="hidden" hidden role="status" aria-live="polite"></div>
     <div id="progress" class="hidden" hidden></div>
 
-    <div id="question-modal" class="hidden" hidden>
+    <div id="question-modal" class="hidden" hidden role="dialog" aria-labelledby="question-text" aria-modal="true">
       <div id="modal-content">
         <p id="question-text"></p>
         <input type="text" id="user-answer" placeholder="Type your answer here..." autocomplete="off">
@@ -88,26 +88,26 @@
       </div>
     </div>
 
-    <div id="celebration-modal" class="hidden" hidden>
+    <div id="celebration-modal" class="hidden" hidden role="dialog" aria-labelledby="celebration-heading" aria-modal="true">
       <div class="celebration-content">
-        <h2>Congratulations!</h2>
+        <h2 id="celebration-heading">Congratulations!</h2>
         <p>You've completed the game board!</p>
         <button id="restart-btn">Play Again</button>
       </div>
     </div>
 
-    <div id="mode-modal" class="hidden" hidden>
+    <div id="mode-modal" class="hidden" hidden role="dialog" aria-labelledby="mode-heading" aria-modal="true">
       <div class="modal-content">
-        <h2>Select Game Mode</h2>
+        <h2 id="mode-heading">Select Game Mode</h2>
         <input id="single-name" type="text" placeholder="Your name">
         <button id="single-mode">Single Player</button>
         <button id="multi-mode">Multiplayer</button>
       </div>
     </div>
 
-    <div id="multi-modal" class="hidden" hidden>
+    <div id="multi-modal" class="hidden" hidden role="dialog" aria-labelledby="multi-heading" aria-modal="true">
       <div class="modal-content">
-        <h2>Multiplayer Setup</h2>
+        <h2 id="multi-heading">Multiplayer Setup</h2>
         <label for="player-count">Number of Players (2-4)</label>
         <input id="player-count" type="number" min="2" max="4" value="2">
         <div id="name-fields"></div>
@@ -115,8 +115,9 @@
       </div>
     </div>
 
-    <div id="quit-modal" class="hidden" hidden>
+    <div id="quit-modal" class="hidden" hidden role="dialog" aria-labelledby="quit-heading" aria-modal="true">
       <div class="modal-content">
+        <h2 id="quit-heading">Quit Game?</h2>
         <p>Your progress may not be saved. Are you sure you want to proceed?</p>
         <button id="quit-yes">Yes</button>
         <button id="quit-no">Cancel</button>

--- a/jeopardy/style.css
+++ b/jeopardy/style.css
@@ -514,6 +514,8 @@ button {
   margin-left: 4px;
   padding: 2px 6px;
   font-size: 14px;
+  background-color: #616161;
+  color: #fff;
 }
 
 @media (max-width: 600px) {
@@ -550,6 +552,8 @@ button {
 
   .player-score button {
     font-size: 12px;
+    background-color: #616161;
+    color: #fff;
   }
 }
 

--- a/timeline/timeline.html
+++ b/timeline/timeline.html
@@ -33,7 +33,7 @@
   </nav>
   <div class="container">
     <h1>Interactive Timeline</h1>
-    <div id="timeline-entry">
+    <div id="timeline-entry" tabindex="0">
       <h2 id="philosopher-name"></h2>
       <h3 id="philosopher-era"></h3>
       <p id="philosopher-bio"></p>

--- a/timeline/timeline.js
+++ b/timeline/timeline.js
@@ -433,6 +433,17 @@ document.getElementById('prev-btn').addEventListener('click', () => {
   displayEntry(currentIndex);
 });
 
+// Arrow key navigation
+document.addEventListener('keydown', (e) => {
+  if (e.key === 'ArrowRight') {
+    currentIndex = (currentIndex + 1) % philosophyTimeline.length;
+    displayEntry(currentIndex);
+  } else if (e.key === 'ArrowLeft') {
+    currentIndex = (currentIndex - 1 + philosophyTimeline.length) % philosophyTimeline.length;
+    displayEntry(currentIndex);
+  }
+});
+
 function initTimelineHover() {
   const container = document.getElementById('timeline-container');
   const bar = document.getElementById('timeline-bar');

--- a/trivia/trivia.html
+++ b/trivia/trivia.html
@@ -22,7 +22,7 @@
       </select>
     </div>
 
-    <div id="trivia-game" class="hidden" hidden>
+    <div id="trivia-game" class="hidden" hidden tabindex="0">
       <p id="trivia-question"></p>
       <div id="trivia-options" class="mc-options"></div>
       <div id="trivia-feedback" class="hidden" hidden></div>

--- a/trivia/trivia.js
+++ b/trivia/trivia.js
@@ -2,6 +2,7 @@ const triviaQuestions = flashcards;
 
 let currentTrivia = [];
 let triviaIndex = 0;
+let optionIndex = 0;
 
 function shuffle(arr) {
   for (let i = arr.length - 1; i > 0; i--) {
@@ -34,11 +35,14 @@ function showTriviaQuestion() {
   document.getElementById('trivia-question').innerText = q.question;
   const optionsDiv = document.getElementById('trivia-options');
   optionsDiv.innerHTML = '';
-  buildChoices(q.answer).forEach(ans => {
+  const choices = buildChoices(q.answer);
+  optionIndex = 0;
+  choices.forEach((ans, idx) => {
     const btn = document.createElement('button');
     btn.className = 'option-btn';
     btn.innerText = ans;
     btn.onclick = () => submitTrivia(ans);
+    btn.tabIndex = idx === 0 ? 0 : -1;
     optionsDiv.appendChild(btn);
   });
   document.getElementById('trivia-feedback').classList.add('hidden');   document.getElementById('trivia-feedback').hidden = true;
@@ -62,6 +66,27 @@ function submitTrivia(choice) {
 document.getElementById('trivia-next').addEventListener('click', () => {
   triviaIndex = (triviaIndex + 1) % currentTrivia.length;
   showTriviaQuestion();
+});
+
+// Keyboard navigation for options
+document.addEventListener('keydown', (e) => {
+  const game = document.getElementById('trivia-game');
+  if (game.classList.contains('hidden')) return;
+  const buttons = Array.from(document.querySelectorAll('#trivia-options button'));
+  if (!buttons.length) return;
+  if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
+    optionIndex = (optionIndex + 1) % buttons.length;
+    buttons.forEach((b, i) => { b.tabIndex = i === optionIndex ? 0 : -1; });
+    buttons[optionIndex].focus();
+    e.preventDefault();
+  } else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
+    optionIndex = (optionIndex - 1 + buttons.length) % buttons.length;
+    buttons.forEach((b, i) => { b.tabIndex = i === optionIndex ? 0 : -1; });
+    buttons[optionIndex].focus();
+    e.preventDefault();
+  } else if (e.key === 'Enter') {
+    buttons[optionIndex].click();
+  }
 });
 
 document.getElementById('trivia-course').addEventListener('change', e => {


### PR DESCRIPTION
## Summary
- enhance scoreboard button contrast
- add ARIA attributes to all Jeopardy modals
- allow arrow-key navigation for flashcards, timeline, and trivia
- set focusable containers with tabindex for interactive pages

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_6859a10034808322935b692901557958