### PR TITLE
Add flip card functionality to flashcards

### DIFF
--- a/flashcards/flashcards.html
+++ b/flashcards/flashcards.html
@@ -28,8 +28,21 @@
     </div>
 
     <div id="flashcard" class="hidden" hidden tabindex="0">
-      <p id="flashcard-question"></p>
-      <p id="flashcard-answer" class="hidden" hidden></p>
+      <div class="flip-card">
+        <div class="flip-card-inner">
+          <div class="flip-card-front">
+            <p id="flashcard-question"></p>
+          </div>
+          <div class="flip-card-back">
+            <p id="flashcard-answer" class="hidden" hidden></p>
+            <div id="review-buttons" class="hidden">
+              <button data-result="easy">Easy</button>
+              <button data-result="hard">Hard</button>
+              <button data-result="review">Review again</button>
+            </div>
+          </div>
+        </div>
+      </div>
       <button id="show-answer">Show Answer</button>
       <button id="next-card">Next Card</button>
       <button id="export-cards">Export</button>

--- a/flashcards/flashcards.js
+++ b/flashcards/flashcards.js
@@ -76,17 +76,29 @@ function loadCards(course, category = 'all') {
 function loadCard() {
   if (!currentCards.length) {
     document.getElementById('flashcard-question').innerText = 'No cards available.';
-    document.getElementById('flashcard-answer').classList.add('hidden');     document.getElementById('flashcard-answer').hidden = true;
+    document.getElementById('flashcard-answer').classList.add('hidden');
+    document.getElementById('flashcard-answer').hidden = true;
+    document.getElementById('review-buttons').classList.add('hidden');
+    document.getElementById('review-buttons').hidden = true;
+    document.querySelector('#flashcard .flip-card').classList.remove('flipped');
     return;
   }
   const card = currentCards[cardIndex];
   document.getElementById('flashcard-question').innerText = card.question;
   document.getElementById('flashcard-answer').innerText = card.answer;
-  document.getElementById('flashcard-answer').classList.add('hidden');   document.getElementById('flashcard-answer').hidden = true;
+  document.getElementById('flashcard-answer').classList.add('hidden');
+  document.getElementById('flashcard-answer').hidden = true;
+  document.getElementById('review-buttons').classList.add('hidden');
+  document.getElementById('review-buttons').hidden = true;
+  document.querySelector('#flashcard .flip-card').classList.remove('flipped');
 }
 
 function showAnswer() {
-  document.getElementById('flashcard-answer').classList.remove('hidden');   document.getElementById('flashcard-answer').hidden = false;
+  document.querySelector('#flashcard .flip-card').classList.add('flipped');
+  document.getElementById('flashcard-answer').classList.remove('hidden');
+  document.getElementById('flashcard-answer').hidden = false;
+  document.getElementById('review-buttons').classList.remove('hidden');
+  document.getElementById('review-buttons').hidden = false;
 }
 
 function nextCard() {
@@ -99,6 +111,15 @@ function prevCard() {
   if (!currentCards.length) return;
   cardIndex = (cardIndex - 1 + currentCards.length) % currentCards.length;
   loadCard();
+}
+
+function saveResult(result) {
+  const card = currentCards[cardIndex];
+  if (!card) return;
+  const key = 'flashcardResults';
+  const data = JSON.parse(localStorage.getItem(key) || '{}');
+  data[card.question] = result;
+  localStorage.setItem(key, JSON.stringify(data));
 }
 
 function exportCards() {
@@ -150,6 +171,12 @@ document.getElementById('show-answer').addEventListener('click', showAnswer);
 document.getElementById('next-card').addEventListener('click', nextCard);
 document.getElementById('export-cards').addEventListener('click', exportCards);
 document.getElementById('quiz-mode').addEventListener('click', startQuiz);
+document.getElementById('review-buttons').addEventListener('click', e => {
+  const result = e.target.dataset.result;
+  if (!result) return;
+  saveResult(result);
+  nextCard();
+});
 
 // Keyboard navigation
 document.addEventListener('keydown', (e) => {

--- a/jeopardy/style.css
+++ b/jeopardy/style.css
@@ -827,3 +827,38 @@ button {
   border-radius: 4px;
   padding: 6px;
 }
+
+/* Flashcard flip animation */
+.flip-card {
+  perspective: 1000px;
+  width: 100%;
+  max-width: 400px;
+  margin: 0 auto 20px;
+}
+
+.flip-card-inner {
+  position: relative;
+  width: 100%;
+  transition: transform 0.6s;
+  transform-style: preserve-3d;
+}
+
+.flip-card.flipped .flip-card-inner {
+  transform: rotateY(180deg);
+}
+
+.flip-card-front,
+.flip-card-back {
+  backface-visibility: hidden;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  padding: 20px;
+  border-radius: 8px;
+  background: #1e1e1e;
+}
+
+.flip-card-back {
+  transform: rotateY(180deg);
+}


### PR DESCRIPTION
## Summary
- wrap flashcard question/answer inside `.flip-card` element
- style `.flip-card` with 3D flip CSS
- toggle `flipped` class in flashcards.js when showing answers
- display rating buttons after revealing the answer and store results in `localStorage`

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6859a58f4598832298d21e0a4eae98f9