### PR TITLE
Add help modal and sharing options

### DIFF
--- a/help-modal.html
+++ b/help-modal.html
@@ -1,0 +1,6 @@
+<div class="modal-content">
+  <h2>How This Works</h2>
+  <p>Each activity on Philosophy MindGames runs entirely in your browser. Select a course or game and follow the prompts to test your knowledge.</p>
+  <p>Use the ? icons near page headings whenever you need a quick refresher.</p>
+  <button id="help-close">Close</button>
+</div>

--- a/jeopardy/index.html
+++ b/jeopardy/index.html
@@ -93,6 +93,10 @@
       <div class="celebration-content">
         <h2 id="celebration-heading">Congratulations!</h2>
         <p>You've completed the game board!</p>
+        <div id="share-controls" class="hidden" hidden>
+          <button id="copy-link">Copy Link</button>
+          <button id="web-share">Share</button>
+        </div>
         <button id="restart-btn">Play Again</button>
       </div>
     </div>

--- a/jeopardy/script.js
+++ b/jeopardy/script.js
@@ -211,6 +211,11 @@ function closeQuestionModal() {
   nextPlayer();
 
   if (remainingQuestions === 0) {
+    const share = document.getElementById('share-controls');
+    if (share) {
+      share.classList.remove('hidden');
+      share.hidden = false;
+    }
     document.getElementById('celebration-modal').classList.remove('hidden');     document.getElementById('celebration-modal').hidden = false;
   }
 }
@@ -226,6 +231,8 @@ function cancelQuestion(cell) {
 
 document.getElementById('restart-btn').onclick = () => {
   document.getElementById('celebration-modal').classList.add('hidden');   document.getElementById('celebration-modal').hidden = true;
+  const share = document.getElementById('share-controls');
+  if (share) share.classList.add('hidden');
   players.forEach(p => p.score = 0);
   updateScoreboard();
   buildBoard();
@@ -245,3 +252,21 @@ document.getElementById('scoreboard').addEventListener('click', (e) => {
 
   updateScoreboard();
 });
+
+const copyBtn = document.getElementById('copy-link');
+if (copyBtn) {
+  copyBtn.addEventListener('click', () => {
+    navigator.clipboard.writeText(window.location.href);
+  });
+}
+
+const shareBtn = document.getElementById('web-share');
+if (shareBtn) {
+  shareBtn.addEventListener('click', () => {
+    if (navigator.share) {
+      navigator.share({ url: window.location.href });
+    } else if (copyBtn) {
+      navigator.clipboard.writeText(window.location.href);
+    }
+  });
+}

--- a/jeopardy/style.css
+++ b/jeopardy/style.css
@@ -69,6 +69,18 @@ a.button:hover {
   background-color: #7b1fa2;
 }
 
+.help-link {
+  margin-left: 8px;
+  color: #9c27b0;
+  text-decoration: none;
+  cursor: pointer;
+  font-size: 18px;
+}
+
+.help-link:hover {
+  text-decoration: underline;
+}
+
 .container {
   width: 100%;
   margin: 80px auto 0;
@@ -317,7 +329,7 @@ body.home .game-links .review-btn {
   display: none;
 }
 
-#question-modal, #celebration-modal, #mode-modal, #multi-modal, #quit-modal, #info-modal {
+#question-modal, #celebration-modal, #mode-modal, #multi-modal, #quit-modal, #info-modal, #help-modal {
   position: fixed;
   inset: 0;
   background: rgba(0, 0, 0, 0.85);
@@ -331,7 +343,8 @@ body.home .game-links .review-btn {
 #mode-modal.hidden,
 #multi-modal.hidden,
 #quit-modal.hidden,
-#info-modal.hidden {
+#info-modal.hidden,
+#help-modal.hidden {
   display: none;
 }
 

--- a/page-header.js
+++ b/page-header.js
@@ -1,4 +1,30 @@
 // Dynamic header text based on query parameters
+function resolvePath(file) {
+  const src = document.currentScript.src;
+  const base = src.substring(0, src.lastIndexOf('/'));
+  return `${base}/${file}`;
+}
+
+function openHelp() {
+  const modal = document.getElementById('help-modal');
+  if (modal) modal.classList.remove('hidden');
+}
+
+function loadHelpModal() {
+  fetch(resolvePath('help-modal.html'))
+    .then(r => r.text())
+    .then(html => {
+      const wrapper = document.createElement('div');
+      wrapper.id = 'help-modal';
+      wrapper.classList.add('hidden');
+      wrapper.hidden = true;
+      wrapper.innerHTML = html;
+      document.body.appendChild(wrapper);
+      const close = wrapper.querySelector('#help-close');
+      if (close) close.addEventListener('click', () => wrapper.classList.add('hidden'));
+    });
+}
+
 window.addEventListener('DOMContentLoaded', () => {
   const header = document.getElementById('page-header');
   if (!header) return;
@@ -14,4 +40,15 @@ window.addEventListener('DOMContentLoaded', () => {
   const h1 = document.querySelector('.container h1');
   const activity = h1 ? h1.textContent.trim() : 'Activity';
   header.textContent = `${course} \u2022 ${activity}`;
+
+  if (h1) {
+    const help = document.createElement('a');
+    help.href = '#';
+    help.className = 'help-link';
+    help.textContent = '?';
+    help.addEventListener('click', (e) => { e.preventDefault(); openHelp(); });
+    h1.appendChild(help);
+  }
+
+  loadHelpModal();
 });

--- a/trivia/trivia.html
+++ b/trivia/trivia.html
@@ -29,6 +29,10 @@
       <div id="trivia-feedback" class="hidden" hidden></div>
       <button id="trivia-next" class="hidden" hidden>Next Question</button>
     </div>
+    <div id="trivia-share" class="hidden" hidden>
+      <button id="trivia-copy">Copy Link</button>
+      <button id="trivia-web-share">Share</button>
+    </div>
   </div>
 
   <script src="../jeopardy/data/ethics.js"></script>

--- a/trivia/trivia.js
+++ b/trivia/trivia.js
@@ -3,6 +3,7 @@ const triviaQuestions = flashcards;
 let currentTrivia = [];
 let triviaIndex = 0;
 let optionIndex = 0;
+let questionsAnswered = 0;
 
 function shuffle(arr) {
   for (let i = arr.length - 1; i > 0; i--) {
@@ -16,6 +17,9 @@ function loadTrivia(course) {
   currentTrivia = Object.values(triviaQuestions[course]).flat();
   shuffle(currentTrivia);
   triviaIndex = 0;
+  questionsAnswered = 0;
+  const share = document.getElementById('trivia-share');
+  if (share) share.classList.add('hidden');
   document.getElementById('trivia-game').classList.remove('hidden');   document.getElementById('trivia-game').hidden = false;
   showTriviaQuestion();
 }
@@ -61,6 +65,14 @@ function submitTrivia(choice) {
   }
   feedback.classList.remove('hidden');   feedback.hidden = false;
   document.getElementById('trivia-next').classList.remove('hidden');   document.getElementById('trivia-next').hidden = false;
+  questionsAnswered++;
+  if (questionsAnswered >= currentTrivia.length) {
+    const share = document.getElementById('trivia-share');
+    if (share) {
+      share.classList.remove('hidden');
+      share.hidden = false;
+    }
+  }
 }
 
 document.getElementById('trivia-next').addEventListener('click', () => {
@@ -109,5 +121,23 @@ window.addEventListener('DOMContentLoaded', () => {
     const select = document.getElementById('trivia-course');
     select.value = course;
     loadTrivia(course);
+  }
+
+  const copy = document.getElementById('trivia-copy');
+  if (copy) {
+    copy.addEventListener('click', () => {
+      navigator.clipboard.writeText(window.location.href);
+    });
+  }
+
+  const share = document.getElementById('trivia-web-share');
+  if (share) {
+    share.addEventListener('click', () => {
+      if (navigator.share) {
+        navigator.share({ url: window.location.href });
+      } else if (copy) {
+        navigator.clipboard.writeText(window.location.href);
+      }
+    });
   }
 });


### PR DESCRIPTION
## Summary
- add generic help-modal.html and inject from page-header.js
- append '?' help link beside each page heading
- show share controls in Jeopardy celebration modal
- add sharing functions in Jeopardy and Trivia
- display sharing section on Trivia completion

## Testing
- `npm test` *(fails: ENOENT: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6859a91e152c832291df2756603e1293