### PR TITLE
Improve course detection and trivia content

### DIFF
--- a/flashcards/flashcards.js
+++ b/flashcards/flashcards.js
@@ -16,7 +16,6 @@ function buildFlashcards() {
     const customSet = window[`${course}Flashcards`];
     if (customSet) {
       mergeSets(flashcards[course], customSet);
-      return;
     }
 
     const variants = [

--- a/page-header.js
+++ b/page-header.js
@@ -35,7 +35,13 @@ window.addEventListener('DOMContentLoaded', () => {
     ethics: 'Ethics',
     writing: 'Writing'
   };
-  const courseKey = params.get('course');
+  let courseKey = params.get('course');
+  if (!courseKey) {
+    const path = window.location.pathname;
+    if (/intro-?philosophy/i.test(path)) courseKey = 'introPhilosophy';
+    else if (/critical-?thinking/i.test(path)) courseKey = 'criticalThinking';
+    else if (/ethics/i.test(path)) courseKey = 'ethics';
+  }
   const course = courseMap[courseKey] || (courseKey ? courseKey : 'Course');
   const h1 = document.querySelector('.container h1');
   const activity = h1 ? h1.textContent.trim() : 'Activity';


### PR DESCRIPTION
## Summary
- detect course from URL path when query param missing
- include exam review banks in flashcards/trivia even if custom sets exist

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6859af5f3b588322a3f9e8ed5d109b65