### PR TITLE
Adjust resource loading for flashcards and trivia

### DIFF
--- a/flashcards/flashcards.html
+++ b/flashcards/flashcards.html
@@ -50,13 +50,6 @@
     </div>
   </div>
 
-  <script src="../jeopardy/data/ethics.js"></script>
-  <script src="../jeopardy/data/ethics-final.js"></script>
-  <script src="../jeopardy/data/critical-thinking.js"></script>
-  <script src="../jeopardy/data/critical-thinking-midterm.js"></script>
-  <script src="../jeopardy/data/critical-thinking-final.js"></script>
-  <script src="../jeopardy/data/intro-philosophy.js"></script>
-  <script src="../jeopardy/data/intro-philosophy-final.js"></script>
   <script src="../jeopardy/data/intro-philosophy-flashcards.js"></script>
   <script src="../jeopardy/data/critical-thinking-flashcards.js"></script>
   <script src="../jeopardy/data/ethics-flashcards.js"></script>

--- a/flashcards/flashcards.js
+++ b/flashcards/flashcards.js
@@ -13,22 +13,10 @@ function buildFlashcards() {
   courses.forEach(course => {
     flashcards[course] = {};
 
-    const customSet = window[`${course}Flashcards`];
-    if (customSet) {
-      mergeSets(flashcards[course], customSet);
-      return;
+    const set = window[`${course}Flashcards`];
+    if (set) {
+      mergeSets(flashcards[course], set);
     }
-
-    const variants = [
-      `${course}Questions`,
-      `${course}MidtermQuestions`,
-      `${course}FinalQuestions`
-    ];
-
-    variants.forEach(name => {
-      const data = window[name];
-      if (data) mergeSets(flashcards[course], data);
-    });
   });
 
   return flashcards;

--- a/trivia/trivia.html
+++ b/trivia/trivia.html
@@ -42,9 +42,6 @@
   <script src="../jeopardy/data/critical-thinking-final.js"></script>
   <script src="../jeopardy/data/intro-philosophy.js"></script>
   <script src="../jeopardy/data/intro-philosophy-final.js"></script>
-  <script src="../jeopardy/data/intro-philosophy-flashcards.js"></script>
-  <script src="../jeopardy/data/critical-thinking-flashcards.js"></script>
-  <script src="../jeopardy/data/ethics-flashcards.js"></script>
   <script src="flashcards.js"></script>
   <script src="trivia.js"></script>
   <script src="../next-activity.js"></script>

--- a/trivia/trivia.js
+++ b/trivia/trivia.js
@@ -1,4 +1,37 @@
-const triviaQuestions = flashcards;
+// Build trivia question sets from the loaded Jeopardy data files
+function mergeTrivia(target, source) {
+  Object.keys(source).forEach(cat => {
+    if (!target[cat]) target[cat] = [];
+    target[cat] = target[cat].concat(source[cat]);
+  });
+}
+
+function buildTriviaQuestions() {
+  const courses = ['introPhilosophy', 'criticalThinking', 'ethics'];
+  const trivia = {};
+
+  courses.forEach(course => {
+    trivia[course] = {};
+
+    const variants = [
+      `${course}Questions`,
+      `${course}MidtermQuestions`,
+      `${course}FinalQuestions`
+    ];
+
+    variants.forEach(name => {
+      const data = window[name];
+      if (data) mergeTrivia(trivia[course], data);
+    });
+  });
+
+  return trivia;
+}
+
+const triviaQuestions = buildTriviaQuestions();
+if (typeof window !== 'undefined') {
+  window.triviaQuestions = triviaQuestions;
+}
 
 let currentTrivia = [];
 let triviaIndex = 0;


### PR DESCRIPTION
## Summary
- limit scripts in `flashcards.html` to flashcard sets
- load only exam question banks in `trivia.html`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6859b734ea7083229426031f7ccc68ce