### PR TITLE
Fix course headers for activity pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,11 +20,11 @@
       <div class="course" data-course="introPhilosophy">
         <h3>Intro to Philosophy</h3>
         <div class="game-links">
-          <a class="button" href="argument-reconstruction/intro-philosophy.html" title="Arguments – Reconstruct basic arguments">Arguments</a>
+          <a class="button" href="argument-reconstruction/intro-philosophy.html?course=introPhilosophy" title="Arguments – Reconstruct basic arguments">Arguments</a>
           <a class="button" href="flashcards/flashcards.html?course=introPhilosophy" title="Flashcards – Study key terms">Flashcards</a>
           <a class="button" href="trivia/trivia.html?course=introPhilosophy" title="Trivia – Quick knowledge quiz">Trivia</a>
-          <a class="button" href="chatbots/intro-philosophy-chat.html" title="Chat – Talk with Kant, Mill, Aristotle…">Chat</a>
-          <a class="button" href="timeline/timeline.html" title="Timeline – Explore philosophers by date">Timeline</a>
+          <a class="button" href="chatbots/intro-philosophy-chat.html?course=introPhilosophy" title="Chat – Talk with Kant, Mill, Aristotle…">Chat</a>
+          <a class="button" href="timeline/timeline.html?course=introPhilosophy" title="Timeline – Explore philosophers by date">Timeline</a>
           <a class="button review-btn" href="#" title="Exam Review – Choose a midterm or final game">Review Games</a>
           <div class="exam-dropdown hidden" hidden>
             <button onclick="location.href='jeopardy/index.html?topic=introPhilosophy&exam=Midterm'" title="Part 1 – Midterm Jeopardy">Part 1</button>
@@ -36,11 +36,11 @@
       <div class="course" data-course="criticalThinking">
         <h3>Critical Thinking</h3>
         <div class="game-links">
-          <a class="button" href="argument-reconstruction/critical-thinking.html" title="Arguments – Practice logical analysis">Arguments</a>
+          <a class="button" href="argument-reconstruction/critical-thinking.html?course=criticalThinking" title="Arguments – Practice logical analysis">Arguments</a>
           <a class="button" href="flashcards/flashcards.html?course=criticalThinking" title="Flashcards – Review logic terms">Flashcards</a>
           <a class="button" href="trivia/trivia.html?course=criticalThinking" title="Trivia – Quick critical thinking quiz">Trivia</a>
-          <a class="button" href="sherlock-mystery/sherlock.html" title="Sherlock Mystery – Solve a logic puzzle">Sherlock Mystery</a>
-          <a class="button" href="debate-duel/debate-duel.html" title="Debate Duel – Argue your side">Debate Duel</a>
+          <a class="button" href="sherlock-mystery/sherlock.html?course=criticalThinking" title="Sherlock Mystery – Solve a logic puzzle">Sherlock Mystery</a>
+          <a class="button" href="debate-duel/debate-duel.html?course=criticalThinking" title="Debate Duel – Argue your side">Debate Duel</a>
           <a class="button review-btn" href="#" title="Exam Review – Choose a midterm or final game">Review Games</a>
           <div class="exam-dropdown hidden" hidden>
             <button onclick="location.href='jeopardy/index.html?topic=criticalThinking&exam=Midterm'" title="Part 1 – Midterm Jeopardy">Part 1</button>
@@ -52,11 +52,11 @@
       <div class="course" data-course="ethics">
         <h3>Ethics</h3>
         <div class="game-links">
-          <a class="button" href="argument-reconstruction/ethics.html" title="Arguments – Evaluate moral reasoning">Arguments</a>
+          <a class="button" href="argument-reconstruction/ethics.html?course=ethics" title="Arguments – Evaluate moral reasoning">Arguments</a>
           <a class="button" href="flashcards/flashcards.html?course=ethics" title="Flashcards – Study ethical theories">Flashcards</a>
           <a class="button" href="trivia/trivia.html?course=ethics" title="Trivia – Quick ethics questions">Trivia</a>
-          <a class="button" href="chatbots/ethics-chat.html" title="Chat – Debate dilemmas with philosophers">Chat</a>
-          <a class="button" href="trolley/trolley.html" title="Trolley Game – Decide who to save">Trolley Game</a>
+          <a class="button" href="chatbots/ethics-chat.html?course=ethics" title="Chat – Debate dilemmas with philosophers">Chat</a>
+          <a class="button" href="trolley/trolley.html?course=ethics" title="Trolley Game – Decide who to save">Trolley Game</a>
           <a class="button review-btn" href="#" title="Exam Review – Choose a midterm or final game">Review Games</a>
           <div class="exam-dropdown hidden" hidden>
             <button onclick="location.href='jeopardy/index.html?topic=ethics&exam=Midterm'" title="Part 1 – Midterm Jeopardy">Part 1</button>
@@ -68,12 +68,12 @@
       <div class="course" data-course="writing">
         <h3>Writing in Philosophy</h3>
         <div class="game-links">
-          <a class="button" href="writing/citation.html" title="Citation Investigator – Spot citation errors">Citation Investigator</a>
-          <a class="button" href="writing/brainstorm.html" title="Mind Mapping – Generate ideas visually">Mind Mapping</a>
-          <a class="button" href="writing/outlining.html" title="Outline Builder – Organize your essay">Outline Builder</a>
-          <a class="button" href="writing/thesis-evaluation.html" title="Thesis Evaluation – Rate possible theses">Thesis Evaluation</a>
-          <a class="button" href="writing/draft-development.html" title="Draft Development – Expand your outline">Draft Development</a>
-          <a class="button" href="writing/peer-review.html" title="Peer Review – Give structured feedback">Peer Review</a>
+          <a class="button" href="writing/citation.html?course=writing" title="Citation Investigator – Spot citation errors">Citation Investigator</a>
+          <a class="button" href="writing/brainstorm.html?course=writing" title="Mind Mapping – Generate ideas visually">Mind Mapping</a>
+          <a class="button" href="writing/outlining.html?course=writing" title="Outline Builder – Organize your essay">Outline Builder</a>
+          <a class="button" href="writing/thesis-evaluation.html?course=writing" title="Thesis Evaluation – Rate possible theses">Thesis Evaluation</a>
+          <a class="button" href="writing/draft-development.html?course=writing" title="Draft Development – Expand your outline">Draft Development</a>
+          <a class="button" href="writing/peer-review.html?course=writing" title="Peer Review – Give structured feedback">Peer Review</a>
         </div>
         <div class="course-progress"><div class="course-progress-bar"></div></div>
       </div>


### PR DESCRIPTION
## Summary
- preserve page-header.js while loading question data
- add `course` param to activity links so page headers display the course name

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6859c2b6d0c08322b95b1e1a1592bd0b