### PR TITLE
Expand peer review workshop

### DIFF
--- a/writing/peer-review.html
+++ b/writing/peer-review.html
@@ -20,17 +20,33 @@
 
     <section id="example" class="hidden" hidden>
       <h2>Peer Review Example</h2>
-      <p id="example-paragraph">Kant says morality has rules, but sometimes rules are too strict, and that can be bad.</p>
-      <textarea id="example-input" rows="3" style="width:90%;"></textarea><br>
+      <p id="example-paragraph">Kant argues that moral rules must hold without exception. Critics reply that this rigidity ignores cases where following a rule creates obvious harm. Consider Kant&rsquo;s claim that lying is always wrong even if it helps protect an innocent person.</p>
+      <div class="review-row">
+        <label>Clarity of Thesis:</label><br>
+        <textarea id="example-thesis" rows="2" style="width:90%;"></textarea>
+      </div>
+      <div class="review-row">
+        <label>Argument Development:</label><br>
+        <textarea id="example-argument" rows="2" style="width:90%;"></textarea>
+      </div>
+      <div class="review-row">
+        <label>Use of Examples/Evidence:</label><br>
+        <textarea id="example-evidence" rows="2" style="width:90%;"></textarea>
+      </div>
+      <div class="review-row">
+        <label>Citation Accuracy:</label><br>
+        <textarea id="example-citation" rows="2" style="width:90%;"></textarea>
+      </div>
       <button id="example-show">Show Example Provided</button>
-      <p id="example-answer" class="hidden" hidden></p>
+      <ul id="example-answer" class="hidden" hidden></ul>
       <button class="next-btn" data-next="practice">Next</button>
     </section>
 
     <section id="practice" class="hidden" hidden>
       <h2>Peer Review Practice</h2>
       <p><strong>Thesis Statement:</strong> Kant’s ethics is too rigid because it demands rules without exceptions.</p>
-      <p>Kant thinks you should always tell the truth. But what if a murderer is at your door? Then telling the truth would get someone killed. This is why Kant’s rules don’t always work.</p>
+      <p>Kant thinks you should always tell the truth. But what if a murderer is at your door? Then telling the truth would get someone killed. This example highlights how strict adherence to Kant’s rule clashes with common-sense morality. Many philosophers argue that moral decisions need flexibility to prevent obvious harm.</p>
+      <p>Imagine a friend hides in your house to escape danger. If you follow Kant strictly, you must reveal their location when questioned. Critics say this shows why any moral system needs room for exceptions.</p>
       <div class="review-row">
         <label>Clarity of Thesis:</label><br>
         <textarea id="crit-thesis" rows="2" style="width:90%;"></textarea>
@@ -60,24 +76,12 @@
     </section>
 
     <section id="template" class="hidden" hidden>
-      <h2>Your Peer Review Template</h2>
-      <label>Reviewed Text Excerpt:</label><br>
-      <textarea id="template-excerpt" rows="4" style="width:90%;"></textarea>
-      <table>
-        <tr><th>Clarity of Thesis</th><td><textarea class="template-field" data-key="thesis" rows="2" style="width:90%;"></textarea></td></tr>
-        <tr><th>Argument Development</th><td><textarea class="template-field" data-key="argument" rows="2" style="width:90%;"></textarea></td></tr>
-        <tr><th>Use of Examples/Evidence</th><td><textarea class="template-field" data-key="evidence" rows="2" style="width:90%;"></textarea></td></tr>
-        <tr><th>Citation Accuracy</th><td><textarea class="template-field" data-key="citation" rows="2" style="width:90%;"></textarea></td></tr>
-        <tr><th>Additional Suggestions</th><td><textarea class="template-field" data-key="extra" rows="2" style="width:90%;"></textarea></td></tr>
-      </table>
-      <div>
-        <button id="export-docx">Export Your Peer Review (DOCX)</button>
-        <button id="export-pdf">Export Your Peer Review (PDF)</button>
-      </div>
+      <h2>Printable Peer Review Template</h2>
+      <p>Download a blank peer review form to print or fill in by hand.</p>
+      <button id="download-template">Download PDF Template</button>
     </section>
   </div>
   <script src="peer-review.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/docx/7.5.0/docx.umd.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
   <script src="../page-header.js"></script>
 </body>

--- a/writing/peer-review.js
+++ b/writing/peer-review.js
@@ -17,10 +17,20 @@ document.querySelectorAll('.next-btn').forEach(btn => {
 });
 
 document.getElementById('example-show').addEventListener('click', () => {
-  const ans = '<strong>Feedback Example:</strong> This paragraph could be stronger with a clearer topic sentence mentioning Kant\'s categorical imperative and a brief example like the Nazi-at-the-door scenario.';
-  const p = document.getElementById('example-answer');
-  p.innerHTML = ans;
-  p.classList.remove('hidden');   p.hidden = false;
+  const list = document.getElementById('example-answer');
+  list.innerHTML = '';
+  const items = [
+    'Clarity of Thesis: Introduce Kant\'s categorical imperative directly.',
+    'Argument Development: Contrast Kant\'s view with situations that require exceptions.',
+    'Use of Examples/Evidence: Mention the murderer-at-the-door scenario.',
+    'Citation Accuracy: Provide a citation from Kant\'s <em>Groundwork</em>.'
+  ];
+  items.forEach(t => {
+    const li = document.createElement('li');
+    li.innerHTML = t;
+    list.appendChild(li);
+  });
+  list.classList.remove('hidden');   list.hidden = false;
 });
 
 document.getElementById('practice-show').addEventListener('click', () => {
@@ -40,61 +50,20 @@ document.getElementById('practice-show').addEventListener('click', () => {
   list.classList.remove('hidden');   list.hidden = false;
 });
 
-function gatherReview() {
-  return {
-    excerpt: document.getElementById('template-excerpt').value.trim(),
-    thesis: document.querySelector('[data-key=thesis]').value.trim(),
-    argument: document.querySelector('[data-key=argument]').value.trim(),
-    evidence: document.querySelector('[data-key=evidence]').value.trim(),
-    citation: document.querySelector('[data-key=citation]').value.trim(),
-    extra: document.querySelector('[data-key=extra]').value.trim()
-  };
-}
-
-function exportDocx() {
-  const { Document, Packer, Paragraph } = window.docx;
-  const data = gatherReview();
-  const doc = new Document();
-  const children = [];
-  if (data.excerpt) {
-    children.push(new Paragraph('Reviewed Text:'), new Paragraph(data.excerpt));
-  }
-  children.push(
-    new Paragraph('Clarity of Thesis: ' + data.thesis),
-    new Paragraph('Argument Development: ' + data.argument),
-    new Paragraph('Use of Examples/Evidence: ' + data.evidence),
-    new Paragraph('Citation Accuracy: ' + data.citation)
-  );
-  if (data.extra) children.push(new Paragraph('Additional Suggestions: ' + data.extra));
-  doc.addSection({ children });
-  Packer.toBlob(doc).then(blob => {
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = 'peer-review.docx';
-    a.click();
-    URL.revokeObjectURL(url);
-  });
-}
-
-function exportPdf() {
+function downloadTemplate() {
   const { jsPDF } = window.jspdf;
-  const data = gatherReview();
   const doc = new jsPDF();
   let y = 10;
-  if (data.excerpt) {
-    doc.text('Reviewed Text:', 10, y); y += 10;
-    doc.text(data.excerpt, 10, y); y += 10;
-  }
-  doc.text('Clarity of Thesis: ' + data.thesis, 10, y); y += 10;
-  doc.text('Argument Development: ' + data.argument, 10, y); y += 10;
-  doc.text('Use of Examples/Evidence: ' + data.evidence, 10, y); y += 10;
-  doc.text('Citation Accuracy: ' + data.citation, 10, y); y += 10;
-  if (data.extra) { doc.text('Additional Suggestions: ' + data.extra, 10, y); }
-  doc.save('peer-review.pdf');
+  doc.text('Peer Review Template', 10, y); y += 10;
+  doc.text('Reviewed Text Excerpt:', 10, y); y += 20;
+  doc.text('Clarity of Thesis:', 10, y); y += 10;
+  doc.text('Argument Development:', 10, y); y += 10;
+  doc.text('Use of Examples/Evidence:', 10, y); y += 10;
+  doc.text('Citation Accuracy:', 10, y); y += 10;
+  doc.text('Additional Suggestions:', 10, y);
+  doc.save('peer-review-template.pdf');
 }
 
-document.getElementById('export-docx').addEventListener('click', exportDocx);
-document.getElementById('export-pdf').addEventListener('click', exportPdf);
+document.getElementById('download-template').addEventListener('click', downloadTemplate);
 
 window.addEventListener('DOMContentLoaded', () => showSection('intro'));


### PR DESCRIPTION
## Summary
- make example section more substantial with separate feedback fields
- extend practice passage with additional context
- provide downloadable PDF template instead of interactive form
- remove DOCX export and adjust script logic accordingly

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6859c73a99588322b644f53ac8afc69c