### PR TITLE
Fix flashcard controls and styling

### DIFF
--- a/flashcards/flashcards.html
+++ b/flashcards/flashcards.html
@@ -31,17 +31,22 @@
       <div class="flip-card">
         <div class="flip-card-inner">
           <div class="flip-card-front">
+            <button class="flashcard-close" type="button">X</button>
             <p id="flashcard-question"></p>
+            <div class="flashcard-controls">
+              <button class="prev-card">Prev Card</button>
+              <button class="next-card">Next Card</button>
+            </div>
           </div>
           <div class="flip-card-back">
+            <button class="flashcard-close" type="button">X</button>
             <p id="flashcard-answer" class="hidden" hidden></p>
+            <div class="flashcard-controls">
+              <button class="prev-card">Prev Card</button>
+              <button class="next-card">Next Card</button>
+            </div>
           </div>
         </div>
-      </div>
-      <button id="exit-cards" class="flashcard-close" type="button">X</button>
-      <div class="flashcard-controls">
-        <button id="prev-card">Prev Card</button>
-        <button id="next-card">Next Card</button>
       </div>
     </div>
   </div>

--- a/flashcards/flashcards.js
+++ b/flashcards/flashcards.js
@@ -26,6 +26,13 @@ const flashcards = buildFlashcards();
 if (typeof window !== 'undefined') {
   window.flashcards = flashcards;
 }
+
+const courseColors = {
+  introPhilosophy: '#9c27b0',
+  criticalThinking: '#f44336',
+  ethics: '#2196f3',
+  writing: '#424242'
+};
 let currentCards = [];
 let cardIndex = 0;
 
@@ -51,13 +58,18 @@ function populateCategories(course) {
 
 function loadCards(course, category = 'all') {
   if (!flashcards[course]) return;
+  const color = courseColors[course] || '#9c27b0';
+  const wrapper = document.getElementById('flashcard');
+  if (wrapper) wrapper.style.setProperty('--flashcard-color', color);
   const allCards = category === 'all'
     ? Object.values(flashcards[course]).flat()
     : (flashcards[course][category] || []);
   currentCards = allCards.slice();
   shuffle(currentCards);
   cardIndex = 0;
-  document.getElementById('flashcard').classList.remove('hidden');   document.getElementById('flashcard').hidden = false;
+  const fc = document.getElementById('flashcard');
+  fc.classList.remove('hidden');
+  fc.hidden = false;
   loadCard();
 }
 
@@ -158,12 +170,19 @@ document.getElementById('category-select').addEventListener('change', e => {
 });
 
 document.querySelector('#flashcard .flip-card').addEventListener('click', toggleFlip);
-document.getElementById('next-card').addEventListener('click', nextCard);
-document.getElementById('prev-card').addEventListener('click', prevCard);
-document.getElementById('exit-cards').addEventListener('click', () => {
-  const flashcard = document.getElementById('flashcard');
-  flashcard.classList.add('hidden');
-  flashcard.hidden = true;
+document.querySelectorAll('.next-card').forEach(btn => {
+  btn.addEventListener('click', e => { e.stopPropagation(); nextCard(); });
+});
+document.querySelectorAll('.prev-card').forEach(btn => {
+  btn.addEventListener('click', e => { e.stopPropagation(); prevCard(); });
+});
+document.querySelectorAll('.flashcard-close').forEach(btn => {
+  btn.addEventListener('click', e => {
+    e.stopPropagation();
+    const flashcard = document.getElementById('flashcard');
+    flashcard.classList.add('hidden');
+    flashcard.hidden = true;
+  });
 });
 
 // Keyboard navigation
@@ -174,7 +193,7 @@ document.addEventListener('keydown', (e) => {
     nextCard();
   } else if (e.key === 'ArrowLeft') {
     prevCard();
-  } else if (e.key === 'Shift') {
+  } else if (e.key === 'Shift' || e.code === 'Space') {
     toggleFlip();
   }
 });

--- a/jeopardy/style.css
+++ b/jeopardy/style.css
@@ -419,6 +419,10 @@ button {
   width: 100%;
 }
 
+.site-footer a {
+  color: #ffeb3b;
+}
+
 #scoreboard {
   margin-top: 20px;
   font-size: 18px;
@@ -849,6 +853,7 @@ button {
   width: 100%;
   max-width: 600px;
   margin: 0 auto 20px;
+  height: 260px;
 }
 
 .flip-card-inner {
@@ -869,9 +874,12 @@ button {
   top: 0;
   left: 0;
   width: 100%;
+  height: 100%;
   padding: 20px;
+  border: 4px solid var(--flashcard-color, #9c27b0);
   border-radius: 8px;
   background: #1e1e1e;
+  z-index: 1;
 }
 
 .flip-card-back {
@@ -909,6 +917,7 @@ button {
   position: absolute;
   top: 8px;
   right: 8px;
+  z-index: 2;
 }
 
 .flashcard-controls {
@@ -917,5 +926,6 @@ button {
   left: 0;
   width: 100%;
   text-align: center;
+  z-index: 2;
 }
 


### PR DESCRIPTION
## Summary
- move prev/next/exit buttons inside the flashcard
- enlarge flashcard and add colored borders
- allow Shift or Space key to flip the card
- color site footer link to match the Who Said It arrow

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6859c86d60c883228f6d273f5290abf4