### PR TITLE
Remove Jeopardy flashcard outline

### DIFF
--- a/jeopardy/style.css
+++ b/jeopardy/style.css
@@ -876,7 +876,6 @@ button {
   width: 100%;
   height: 100%;
   padding: 20px;
-  border: 4px solid var(--flashcard-color, #9c27b0);
   border-radius: 8px;
   background: #1e1e1e;
   z-index: 1;


### PR DESCRIPTION
## Summary
- remove purple outline from Jeopardy flashcards

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6859cc8fbd688322b1f737fd10bde211