### PR TITLE
Remove citation manager and update resources

### DIFF
--- a/writing/citation-aid.html
+++ b/writing/citation-aid.html
@@ -36,7 +36,11 @@
     </section>
     <section>
       <h2>Additional Resources</h2>
-      <p>For more examples, consult a trusted MLA style guide or your instructor's recommendations.</p>
+      <ul>
+        <li><a href="https://owl.purdue.edu" target="_blank">Purdue OWL</a> overview of MLA formatting.</li>
+        <li>Free citation managers such as <a href="https://www.zotero.org" target="_blank">Zotero</a>, <a href="https://www.mendeley.com" target="_blank">Mendeley</a>, and <a href="https://endnote.com" target="_blank">EndNote</a> help organize references.</li>
+        <li>Use the "Cite" or "Export" option on <a href="https://scholar.google.com" target="_blank">Google Scholar</a> or your library's website to download citations to these tools or copy formatted entries.</li>
+      </ul>
       <button onclick="location.href='citation.html'">Return to Citation Investigator</button>
     </section>
   </div>

--- a/writing/citation.html
+++ b/writing/citation.html
@@ -21,22 +21,10 @@
       <div id="citation-answer" class="hidden" hidden></div>
       <button id="citation-next" class="hidden" hidden>Next</button>
     </div>
-    <p id="research-guide" class="hidden" hidden>Explore your own peer-reviewed sources using <a href="https://scholar.google.com" target="_blank">scholar.google.com</a> or your college library. Then open the citation manager below to track your references.</p>
-    <button id="start-project" class="hidden" hidden>Open Citation Manager</button>
-    <div id="project-area" class="project-area hidden" hidden>
-      <h2>Citation Manager</h2>
-      <form id="citation-form">
-        <input id="cite-author" placeholder="Author">
-        <input id="cite-title" placeholder="Title">
-        <input id="cite-source" placeholder="Source">
-      </form>
-      <button id="export-citation">Export as DOCX</button>
-      <button id="reset-citation">Reset</button>
-    </div>
+    <p id="research-guide" class="hidden" hidden>Explore your own peer-reviewed sources using <a href="https://scholar.google.com" target="_blank">scholar.google.com</a> or your college library. Use the "Cite" or "Export" options to save references to tools like <a href="https://www.zotero.org" target="_blank">Zotero</a>, <a href="https://www.mendeley.com" target="_blank">Mendeley</a>, or <a href="https://endnote.com" target="_blank">EndNote</a>. For MLA guidelines see <a href="https://owl.purdue.edu" target="_blank">Purdue OWL</a>.</p>
     <button id="citation-aid-link" class="hidden" hidden>Citation Guide</button>
   </div>
   <script src="citation.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/docx/7.5.0/docx.umd.min.js"></script>
   <script src="../page-header.js"></script>
 </body>
 </html>

--- a/writing/citation.js
+++ b/writing/citation.js
@@ -101,47 +101,14 @@ document.getElementById('citation-next').addEventListener('click', () => {
     citationIndex = 0;
     completedRounds++;
     if (completedRounds === 1) {
-      document.getElementById('citation-aid-link').classList.remove('hidden');       document.getElementById('citation-aid-link').hidden = false;
-      document.getElementById('start-project').classList.remove('hidden');       document.getElementById('start-project').hidden = false;
-      document.getElementById('research-guide').classList.remove('hidden');       document.getElementById('research-guide').hidden = false;
-    }
+        document.getElementById('citation-aid-link').classList.remove('hidden');       document.getElementById('citation-aid-link').hidden = false;
+        document.getElementById('research-guide').classList.remove('hidden');       document.getElementById('research-guide').hidden = false;
+      }
   }
   buildCitation();
 });
 
 window.addEventListener('DOMContentLoaded', buildCitation);
-
-// Project mode
-document.getElementById('start-project').addEventListener('click', () => {
-  document.getElementById('project-area').classList.remove('hidden');   document.getElementById('project-area').hidden = false;
-});
-
-document.getElementById('reset-citation').addEventListener('click', () => {
-  document.getElementById('citation-form').reset();
-});
-
-document.getElementById('export-citation').addEventListener('click', () => {
-  const { Document, Packer, Paragraph, TextRun } = window.docx;
-  const doc = new Document();
-  const author = document.getElementById('cite-author').value;
-  const title = document.getElementById('cite-title').value;
-  const source = document.getElementById('cite-source').value;
-  doc.addSection({
-    children: [
-      new Paragraph(author),
-      new Paragraph(title),
-      new Paragraph(source)
-    ]
-  });
-  Packer.toBlob(doc).then(blob => {
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = 'citation.docx';
-    a.click();
-    URL.revokeObjectURL(url);
-  });
-});
 
 document.getElementById('citation-aid-link').addEventListener('click', () => {
   window.open('citation-aid.html', '_blank');


### PR DESCRIPTION
## Summary
- drop the citation manager section from Citation Investigator
- remove related JavaScript export code
- add links to Zotero, Mendeley and EndNote with instructions for saving citations

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6859d30c86848322864cbc87672e9ad0