### PR TITLE
Fix brainstorming drop zone styles

### DIFF
--- a/writing/brainstorm.html
+++ b/writing/brainstorm.html
@@ -44,7 +44,11 @@
       min-height:60px;
       border-radius:8px;
     }
-    .cluster ul { list-style:none; padding:0; }
+    .cluster ul {
+      list-style: none;
+      padding: 0;
+      min-height: 40px;  /* allow drop target when empty */
+    }
     .cluster li {
       background:#ba68c8;
       color:#000;


### PR DESCRIPTION
## Summary
- tweak `.cluster ul` style in `brainstorm.html` so empty clusters are easier drop targets

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6859d7df4d3c83229db2f6fc6790c00e