### PR TITLE
Fix flashcard layout so text and buttons show

### DIFF
--- a/jeopardy/style.css
+++ b/jeopardy/style.css
@@ -880,6 +880,9 @@ button {
   background: #1e1e1e;
   z-index: 1;
   overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
 }
 
 .flip-card-back {
@@ -924,7 +927,7 @@ button {
 }
 
 .flashcard-controls {
-  margin-top: 20px;
+  margin-top: auto;
   text-align: center;
 }
 


### PR DESCRIPTION
## Summary
- ensure flashcard sides use flex layout
- keep controls pinned to the bottom of the card

## Testing
- `git diff --color`


------
https://chatgpt.com/codex/tasks/task_e_6859d7dccd348322a6a6dc4afc41b143