### PR TITLE
Implement dynamic mind mapping clusters

### DIFF
--- a/writing/brainstorm.html
+++ b/writing/brainstorm.html
@@ -43,6 +43,10 @@
       margin:10px 0;
       min-height:60px;
       border-radius:8px;
+      position:relative;
+    }
+    .cluster h3 {
+      margin-top:0;
     }
     .cluster ul {
       list-style: none;
@@ -60,6 +64,19 @@
       position:relative;
     }
     .cluster li button.delete {
+      position:absolute;
+      top:0;
+      right:0;
+      background:#777;
+      border:none;
+      color:#fff;
+      border-radius:50%;
+      width:16px;
+      height:16px;
+      font-size:12px;
+      cursor:pointer;
+    }
+    .cluster button.cluster-delete {
       position:absolute;
       top:0;
       right:0;
@@ -103,11 +120,8 @@
     <button id="start-project">Start Your Own Project</button>
     <div id="project-area" class="project-area hidden" hidden>
       <h2>Your Mind Map</h2>
-      <div id="mindmap">
-        <div class="cluster"><h3>Cluster 1</h3><ul contenteditable="true"></ul></div>
-        <div class="cluster"><h3>Cluster 2</h3><ul contenteditable="true"></ul></div>
-        <div class="cluster"><h3>Cluster 3</h3><ul contenteditable="true"></ul></div>
-      </div>
+      <div id="mindmap"></div>
+      <button id="add-cluster">Add Cluster</button>
       <button id="export-mindmap">Export as PNG</button>
       <button id="export-pdf">Export as PDF</button>
       <button id="reset-mindmap">Reset</button>

--- a/writing/brainstorm.js
+++ b/writing/brainstorm.js
@@ -66,13 +66,30 @@ function editNode(li) {
   }
 }
 
-function makeDroppable(container) {
+function createCluster(name) {
+  const div = document.createElement('div');
+  div.className = 'cluster';
+  const h3 = document.createElement('h3');
+  h3.textContent = name;
+  h3.contentEditable = true;
+  const del = document.createElement('button');
+  del.className = 'cluster-delete';
+  del.textContent = '\u00d7';
+  del.addEventListener('click', () => div.remove());
+  const ul = document.createElement('ul');
+  div.append(h3, ul, del);
+  makeDroppable(div, ul);
+  makeDroppable(ul);
+  return div;
+}
+
+function makeDroppable(container, target) {
   container.addEventListener('dragover', e => e.preventDefault());
   container.addEventListener('drop', e => {
     e.preventDefault();
     const id = e.dataTransfer.getData('text/plain');
     const item = document.getElementById(id);
-    if (item) container.appendChild(item);
+    if (item) (target || container).appendChild(item);
   });
 }
 
@@ -82,7 +99,11 @@ function buildPool() {
 
 function enableDrops() {
   makeDroppable(document.getElementById('concept-pool'));
-  document.querySelectorAll('.drop-zone ul, #mindmap .cluster ul').forEach(makeDroppable);
+  document.querySelectorAll('.drop-zone, #mindmap .cluster').forEach(div => {
+    const ul = div.querySelector('ul');
+    makeDroppable(div, ul);
+    if (ul) makeDroppable(ul);
+  });
 }
 
 document.getElementById('show-suggested').addEventListener('click', () => {
@@ -116,11 +137,33 @@ window.addEventListener('DOMContentLoaded', () => {
 
 // Project mode
 document.getElementById('start-project').addEventListener('click', () => {
-  document.getElementById('project-area').classList.remove('hidden');   document.getElementById('project-area').hidden = false;
+  const proj = document.getElementById('project-area');
+  proj.classList.remove('hidden');
+  proj.hidden = false;
+  resetMindMap();
+  const mindmap = document.getElementById('mindmap');
+  const names = [];
+  for (let i = 1; i <= 3; i++) {
+    const optional = i > 2 ? ' (optional)' : '';
+    const name = prompt(`Enter a name for cluster ${i}${optional}`);
+    if (!name) {
+      if (i <= 2) { i--; continue; }
+      break;
+    }
+    names.push(name);
+    if (i === 3 && !name) break;
+  }
+  names.forEach(n => mindmap.appendChild(createCluster(n)));
+  enableDrops();
+  let term;
+  while ((term = prompt('Add a term to sort (leave blank to finish)'))){
+    addNode(term);
+  }
 });
 
 function resetMindMap() {
-  document.querySelectorAll('#mindmap .cluster ul').forEach(ul => ul.innerHTML = '');
+  document.getElementById('mindmap').innerHTML = '';
+  document.getElementById('concept-pool').innerHTML = '';
 }
 
 function exportMindMap() {
@@ -147,3 +190,10 @@ function exportMindMapPDF() {
 document.getElementById('reset-mindmap').addEventListener('click', resetMindMap);
 document.getElementById('export-mindmap').addEventListener('click', exportMindMap);
 document.getElementById('export-pdf').addEventListener('click', exportMindMapPDF);
+document.getElementById('add-cluster').addEventListener('click', () => {
+  const name = prompt('Cluster name');
+  if (name) {
+    document.getElementById('mindmap').appendChild(createCluster(name));
+    enableDrops();
+  }
+});


### PR DESCRIPTION
## Summary
- allow cluster headings to be edited and add removal button
- make full clusters droppable so terms can be dropped anywhere
- remove preset project clusters and reset map on project start
- prompt for initial cluster names and starting terms
- allow adding new clusters on demand

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6859dd70b72c83229c91faf15b01b6c2