### PR TITLE
Expand draft schedule editor

### DIFF
--- a/writing/draft-development.html
+++ b/writing/draft-development.html
@@ -5,6 +5,20 @@
   <title>Φ Gaming</title>
   <link rel="stylesheet" href="../jeopardy/style.css">
   <link rel="icon" href="../favicon.png" type="image/png">
+  <style>
+    .schedule-block {
+      display: inline-block;
+      padding: 2px 4px;
+      margin: 2px;
+      border-radius: 4px;
+      color: #fff;
+    }
+    .schedule-block.draft { background: #2196f3; }
+    .schedule-block.revise { background: #4caf50; }
+    .schedule-block.work { background: #9e9e9e; }
+    .blocks-container input, .blocks-container select { margin-right: 4px; }
+    .add-block { margin-left: 6px; }
+  </style>
 </head>
 <body>
   <nav id="top-nav">
@@ -85,12 +99,12 @@
       <label for="num-days">Days until completion:</label>
       <input id="num-days" type="number" min="1" value="7"><br>
       <button id="build-schedule">Build Plan</button>
-      <table id="schedule-table" class="hidden" hidden>
-        <thead>
-          <tr><th>Day</th><th>Drafting Hours</th><th>Revision Hours</th></tr>
-        </thead>
-        <tbody></tbody>
-      </table>
+      <div id="legend" class="hidden" hidden>
+        <span class="schedule-block draft">Draft</span>
+        <span class="schedule-block revise">Revise</span>
+        <span class="schedule-block work">Work/Class</span>
+      </div>
+      <div id="schedule-container" class="hidden" hidden></div>
       <button id="export-schedule" class="hidden" hidden>Export Plan (PDF)</button>
       <div id="schedule-guidance">
         <h3>Writing Guidance</h3>

--- a/writing/draft-development.js
+++ b/writing/draft-development.js
@@ -46,18 +46,44 @@ document.getElementById('revise-btn').addEventListener('click', () => {
   }
 });
 
+function addBlock(container, start = '08:00', end = '09:00', type = 'draft') {
+  const block = document.createElement('div');
+  block.className = `schedule-block ${type}`;
+  block.innerHTML = `<input type="time" class="start" value="${start}"> - <input type="time" class="end" value="${end}">` +
+    `<select class="activity"><option value="draft">Draft</option><option value="revise">Revise</option><option value="work">Work/Class</option></select>` +
+    ` <button class="remove-block">\u2715</button>`;
+  const select = block.querySelector('select');
+  select.value = type;
+  select.addEventListener('change', () => {
+    block.className = `schedule-block ${select.value}`;
+  });
+  block.querySelector('.remove-block').addEventListener('click', () => block.remove());
+  container.appendChild(block);
+}
+
 function buildSchedule() {
   const days = parseInt(document.getElementById('num-days').value, 10);
-  const tbody = document.querySelector('#schedule-table tbody');
-  tbody.innerHTML = '';
+  const container = document.getElementById('schedule-container');
+  container.innerHTML = '';
   for (let i = 1; i <= days; i++) {
-    const tr = document.createElement('tr');
-    tr.innerHTML = `<td>Day ${i}</td><td><input type="number" min="0" step="0.5"></td><td><input type="number" min="0" step="0.5"></td>`;
-    tbody.appendChild(tr);
+    const dayDiv = document.createElement('div');
+    dayDiv.className = 'day-schedule';
+    dayDiv.dataset.day = i;
+    dayDiv.innerHTML = `<h3>Day ${i}</h3>`;
+    const blocks = document.createElement('div');
+    blocks.className = 'blocks-container';
+    dayDiv.appendChild(blocks);
+    const add = document.createElement('button');
+    add.textContent = 'Add Block';
+    add.className = 'add-block';
+    add.addEventListener('click', () => addBlock(blocks));
+    dayDiv.appendChild(add);
+    container.appendChild(dayDiv);
   }
-  const table = document.getElementById('schedule-table');
-  table.classList.remove('hidden');
-  table.hidden = false;
+  document.getElementById('legend').classList.remove('hidden');
+  document.getElementById('legend').hidden = false;
+  container.classList.remove('hidden');
+  container.hidden = false;
   const btn = document.getElementById('export-schedule');
   btn.classList.remove('hidden');
   btn.hidden = false;
@@ -68,12 +94,19 @@ function exportSchedule() {
   const doc = new jsPDF();
   doc.text('Drafting Schedule', 10, 10);
   let y = 20;
-  const rows = document.querySelectorAll('#schedule-table tbody tr');
-  rows.forEach((row, i) => {
-    const draft = row.cells[1].querySelector('input').value || '0';
-    const rev = row.cells[2].querySelector('input').value || '0';
-    doc.text(`Day ${i + 1}: draft ${draft}h, revise ${rev}h`, 10, y);
-    y += 10;
+  const days = document.querySelectorAll('.day-schedule');
+  days.forEach(day => {
+    const num = day.dataset.day;
+    doc.text(`Day ${num}`, 10, y);
+    y += 6;
+    day.querySelectorAll('.schedule-block').forEach(block => {
+      const start = block.querySelector('.start').value;
+      const end = block.querySelector('.end').value;
+      const type = block.querySelector('.activity').value;
+      doc.text(`  ${start}-${end} ${type}`, 12, y);
+      y += 6;
+    });
+    y += 4;
   });
   doc.save('schedule.pdf');
 }


### PR DESCRIPTION
## Summary
- expand schedule planner UI
- allow adding/removing time blocks with activity types
- color-code blocks for drafting, revising, and work/class
- include legend for block colors
- export all scheduled blocks to PDF

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_6859e30cc50c8322a3b93d65fb6b85a4