### PR TITLE
Add draft dev shortcut and rename worksheet to outline

### DIFF
--- a/writing/outlining.html
+++ b/writing/outlining.html
@@ -67,12 +67,13 @@
     <div id="hint-text" class="hidden" hidden></div>
     <div id="congrats" class="hidden" hidden></div>
     <p id="summary" class="hidden" hidden><strong>Remember:</strong> Clear outlines guide readers step by step through your argument.</p>
-    <button id="draft-btn">Open Draft Worksheet</button>
-    <div id="draft-area" class="project-area hidden" hidden>
-      <h2>Draft Worksheet</h2>
+    <button id="outline-btn">Open Outline Worksheet</button>
+    <button id="open-draft-dev">Open Draft Development</button>
+    <div id="outline-area" class="project-area hidden" hidden>
+      <h2>Outline Worksheet</h2>
       <label>Thesis Statement:</label><br>
-      <textarea id="draft-thesis" rows="2" style="width:90%;" placeholder="Write your thesis here..."></textarea>
-      <div id="draft-body">
+      <textarea id="outline-thesis" rows="2" style="width:90%;" placeholder="Write your thesis here..."></textarea>
+      <div id="outline-body">
         <div class="body-section">
           <label>Topic Sentence:</label><br>
           <textarea class="topic-input" rows="2" style="width:90%;"></textarea><br>
@@ -94,12 +95,12 @@
       </div>
       <button id="add-paragraph">Add Paragraph</button><br>
       <label>Conclusion:</label><br>
-      <textarea id="draft-conclusion" rows="2" style="width:90%;" placeholder="Summarize your argument..."></textarea><br>
+      <textarea id="outline-conclusion" rows="2" style="width:90%;" placeholder="Summarize your argument..."></textarea><br>
       <label>References:</label><br>
-      <textarea id="draft-references" rows="3" style="width:90%;" placeholder="Enter references..."></textarea>
+      <textarea id="outline-references" rows="3" style="width:90%;" placeholder="Enter references..."></textarea>
       <div>
-        <button id="export-draft-docx">Export Draft (DOCX)</button>
-        <button id="export-draft-pdf">Export Draft (PDF)</button>
+        <button id="export-outline-docx">Export Outline (DOCX)</button>
+        <button id="export-outline-pdf">Export Outline (PDF)</button>
       </div>
     </div>
   </div>

--- a/writing/outlining.js
+++ b/writing/outlining.js
@@ -180,9 +180,13 @@ document.getElementById('add-piece').addEventListener('click', () => {
   }
 });
 
-document.getElementById('draft-btn').addEventListener('click', () => {
-  document.getElementById('draft-area').classList.remove('hidden');
-  document.getElementById('draft-area').hidden = false;
+document.getElementById('outline-btn').addEventListener('click', () => {
+  document.getElementById('outline-area').classList.remove('hidden');
+  document.getElementById('outline-area').hidden = false;
+});
+
+document.getElementById('open-draft-dev').addEventListener('click', () => {
+  window.location.href = 'draft-development.html';
 });
 
 document.getElementById('add-paragraph').addEventListener('click', () => {
@@ -192,14 +196,14 @@ document.getElementById('add-paragraph').addEventListener('click', () => {
   <textarea class="topic-input" rows="2" style="width:90%;"></textarea><br>
   <label>Supporting Details:</label><br>
   <textarea class="detail-input" rows="3" style="width:90%;"></textarea>`;
-  document.getElementById('draft-body').appendChild(div);
+  document.getElementById('outline-body').appendChild(div);
 });
 
-function gatherDraft() {
-  const thesis = document.getElementById('draft-thesis').value.trim();
-  const conclusion = document.getElementById('draft-conclusion').value.trim();
-  const refs = document.getElementById('draft-references').value.trim().split(/\n+/);
-  const bodies = Array.from(document.querySelectorAll('#draft-body .body-section')).map(sec => {
+function gatherOutline() {
+  const thesis = document.getElementById('outline-thesis').value.trim();
+  const conclusion = document.getElementById('outline-conclusion').value.trim();
+  const refs = document.getElementById('outline-references').value.trim().split(/\n+/);
+  const bodies = Array.from(document.querySelectorAll('#outline-body .body-section')).map(sec => {
     return {
       topic: sec.querySelector('.topic-input').value.trim(),
       detail: sec.querySelector('.detail-input').value.trim()
@@ -208,9 +212,9 @@ function gatherDraft() {
   return { thesis, bodies, conclusion, refs };
 }
 
-function exportDraftDocx() {
+function exportOutlineDocx() {
   const { Document, Packer, Paragraph } = window.docx;
-  const data = gatherDraft();
+  const data = gatherOutline();
   const doc = new Document();
   const children = [new Paragraph(data.thesis)];
   data.bodies.forEach(b => {
@@ -227,15 +231,15 @@ function exportDraftDocx() {
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
     a.href = url;
-    a.download = 'draft.docx';
+    a.download = 'outline.docx';
     a.click();
     URL.revokeObjectURL(url);
   });
 }
 
-function exportDraftPdf() {
+function exportOutlinePdf() {
   const { jsPDF } = window.jspdf;
-  const data = gatherDraft();
+  const data = gatherOutline();
   const doc = new jsPDF();
   let y = 10;
   doc.text(data.thesis, 10, y); y += 10;
@@ -248,8 +252,8 @@ function exportDraftPdf() {
     doc.text('References:', 10, y); y += 10;
     data.refs.forEach(r => { doc.text(r, 10, y); y += 10; });
   }
-  doc.save('draft.pdf');
+  doc.save('outline.pdf');
 }
 
-document.getElementById('export-draft-docx').addEventListener('click', exportDraftDocx);
-document.getElementById('export-draft-pdf').addEventListener('click', exportDraftPdf);
+document.getElementById('export-outline-docx').addEventListener('click', exportOutlineDocx);
+document.getElementById('export-outline-pdf').addEventListener('click', exportOutlinePdf);


### PR DESCRIPTION
## Summary
- rename 'Draft Worksheet' references to 'Outline Worksheet'
- add a button to open Draft Development
- update JS ids and functions for outline

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6859e7035e888322aa53bf7e821fa34d