### PR TITLE
Remove unused PNG export

### DIFF
--- a/writing/brainstorm.html
+++ b/writing/brainstorm.html
@@ -113,13 +113,11 @@
     <button id="show-suggested">Show Suggested Clusters</button>
     <div id="suggested" class="hidden" hidden></div>
     <button id="add-cluster">Add Cluster</button>
-    <button id="export-mindmap">Export as PNG</button>
     <button id="export-pdf">Export as PDF</button>
     <button id="clear-map">Clear Map</button>
   </div>
   <script src="brainstorm.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/canvas-to-image@1.0.4/dist/canvas-to-image.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
   <script src="../page-header.js"></script>
 </body>

--- a/writing/brainstorm.js
+++ b/writing/brainstorm.js
@@ -146,13 +146,6 @@ function resetMindMap() {
   enableDrops();
 }
 
-function exportMindMap() {
-  const area = document.getElementById('clusters');
-  html2canvas(area).then(canvas => {
-    canvasToImage(canvas, { name: 'mindmap', type: 'png', quality: 1 });
-  });
-}
-
 function exportMindMapPDF() {
   const area = document.getElementById('clusters');
   html2canvas(area).then(canvas => {
@@ -168,7 +161,6 @@ function exportMindMapPDF() {
 }
 
 document.getElementById('clear-map').addEventListener('click', resetMindMap);
-document.getElementById('export-mindmap').addEventListener('click', exportMindMap);
 document.getElementById('export-pdf').addEventListener('click', exportMindMapPDF);
 document.getElementById('add-cluster').addEventListener('click', () => {
   const cluster = createCluster('New Cluster');


### PR DESCRIPTION
## Summary
- drop the PNG export button and library from the brainstorming page
- remove export function and event listener in `brainstorm.js`

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6859e99795188322b5396244830af85a