### PR TITLE
Remove Add Prompt functionality from thesis evaluation

### DIFF
--- a/writing/thesis-evaluation.html
+++ b/writing/thesis-evaluation.html
@@ -46,7 +46,6 @@
           <textarea rows="2" class="answer" style="width:90%;"></textarea>
         </div>
       </div>
-      <button id="add-prompt">Add Prompt</button>
     </section>
     <button id="start-project">Start Your Own Project</button>
     <div id="project-area" class="project-area hidden" hidden>

--- a/writing/thesis-evaluation.js
+++ b/writing/thesis-evaluation.js
@@ -84,27 +84,6 @@ document.getElementById('export-thesis').addEventListener('click', () => {
     URL.revokeObjectURL(url);
   });
 });
-
-function addPrompt(text = 'New prompt') {
-  const container = document.getElementById('questions');
-  const div = document.createElement('div');
-  div.className = 'prompt';
-  const label = document.createElement('label');
-  label.contentEditable = 'true';
-  label.innerText = text;
-  const ta = document.createElement('textarea');
-  ta.rows = 2;
-  ta.className = 'answer';
-  ta.style.width = '90%';
-  div.append(label, document.createElement('br'), ta);
-  container.appendChild(div);
-}
-
-document.getElementById('add-prompt').addEventListener('click', () => {
-  const text = prompt('Enter a new prompt question:');
-  if (text) addPrompt(text);
-});
-
 document.getElementById('export-all').addEventListener('click', () => {
   const { Document, Packer, Paragraph } = window.docx;
   const doc = new Document();


### PR DESCRIPTION
## Summary
- remove the Add Prompt button from the thesis evaluation page
- delete the `addPrompt` function and its event listener

## Testing
- `node --check writing/thesis-evaluation.js`

------
https://chatgpt.com/codex/tasks/task_e_6859e99440948322b6fb7c1ab0180344