### PR TITLE
Limit reconstruction questions and show summary

### DIFF
--- a/argument-reconstruction/critical-thinking.html
+++ b/argument-reconstruction/critical-thinking.html
@@ -26,6 +26,7 @@
       </div>
       <button id="reconstruction-next" class="hidden" hidden>Next</button>
     </div>
+    <div id="summary" class="hidden" hidden></div>
   </div>
 
   <div id="info-modal" class="hidden" hidden>
@@ -38,6 +39,7 @@
   </div>
 
   <script src="critical-thinking.js"></script>
+  <script src="../next-activity.js"></script>
   <script src="../page-header.js"></script>
 </body>
 </html>

--- a/argument-reconstruction/critical-thinking.js
+++ b/argument-reconstruction/critical-thinking.js
@@ -113,6 +113,8 @@ const reconstructionQuestions = [
 
 let reconstructionOrder = [];
 let reconstructionIndex = 0;
+let currentCourse = '';
+const MAX_QUESTIONS = 10;
 
 function shuffle(arr) {
   for (let i = arr.length - 1; i > 0; i--) {
@@ -124,6 +126,7 @@ function shuffle(arr) {
 function startReconstruction() {
   reconstructionOrder = reconstructionQuestions.slice();
   shuffle(reconstructionOrder);
+  reconstructionOrder = reconstructionOrder.slice(0, MAX_QUESTIONS);
   reconstructionIndex = 0;
   showReconstructionQuestion();
 }
@@ -196,15 +199,36 @@ function tryAgain() {
   controls.hidden = true;
 }
 
+function showSummary() {
+  const game = document.getElementById('reconstruction-game');
+  if (game) {
+    game.classList.add('hidden');
+    game.hidden = true;
+  }
+  const summary = document.getElementById('summary');
+  if (summary) {
+    summary.classList.remove('hidden');
+    summary.hidden = false;
+  }
+  if (typeof showNextActivity === 'function') {
+    showNextActivity(currentCourse);
+  }
+}
+
 document.getElementById("reconstruction-next").addEventListener("click", () => {
-  reconstructionIndex = (reconstructionIndex + 1) % reconstructionOrder.length;
-  showReconstructionQuestion();
+  reconstructionIndex++;
+  if (reconstructionIndex >= reconstructionOrder.length) {
+    showSummary();
+  } else {
+    showReconstructionQuestion();
+  }
 });
 
 document.getElementById("reconstruction-show-answer").addEventListener("click", showAnswer);
 document.getElementById("reconstruction-try-again").addEventListener("click", tryAgain);
 
 document.addEventListener("DOMContentLoaded", () => {
+  currentCourse = getCourse ? getCourse() : '';
   startReconstruction();
   const open = document.getElementById("open-info");
   const close = document.getElementById("close-info");

--- a/argument-reconstruction/ethics.html
+++ b/argument-reconstruction/ethics.html
@@ -26,6 +26,8 @@
       <button id="reconstruction-next" class="hidden" hidden>Next</button>
     </div>
 
+    <div id="summary" class="hidden" hidden></div>
+
 
   </div>
 
@@ -38,6 +40,7 @@
   </div>
 
   <script src="ethics.js"></script>
+  <script src="../next-activity.js"></script>
   <script src="../page-header.js"></script>
 </body>
 </html>

--- a/argument-reconstruction/ethics.js
+++ b/argument-reconstruction/ethics.js
@@ -124,6 +124,8 @@ const reconstructionQuestions = [
 
 let reconstructionOrder = [];
 let reconstructionIndex = 0;
+let currentCourse = '';
+const MAX_QUESTIONS = 10;
 
 function shuffle(arr) {
   for (let i = arr.length - 1; i > 0; i--) {
@@ -135,6 +137,7 @@ function shuffle(arr) {
 function startReconstruction() {
   reconstructionOrder = reconstructionQuestions.slice();
   shuffle(reconstructionOrder);
+  reconstructionOrder = reconstructionOrder.slice(0, MAX_QUESTIONS);
   reconstructionIndex = 0;
   showReconstructionQuestion();
 }
@@ -192,8 +195,12 @@ function submitReconstruction(choice) {
 }
 
 document.getElementById("reconstruction-next").addEventListener("click", () => {
-  reconstructionIndex = (reconstructionIndex + 1) % reconstructionOrder.length;
-  showReconstructionQuestion();
+  reconstructionIndex++;
+  if (reconstructionIndex >= reconstructionOrder.length) {
+    showSummary();
+  } else {
+    showReconstructionQuestion();
+  }
 });
 
 document.getElementById("reconstruction-try").addEventListener("click", () => {
@@ -226,7 +233,24 @@ document.getElementById("reconstruction-show").addEventListener("click", () => {
   nextBtn.hidden = false;
 });
 
+function showSummary() {
+  const game = document.getElementById('reconstruction-game');
+  if (game) {
+    game.classList.add('hidden');
+    game.hidden = true;
+  }
+  const summary = document.getElementById('summary');
+  if (summary) {
+    summary.classList.remove('hidden');
+    summary.hidden = false;
+  }
+  if (typeof showNextActivity === 'function') {
+    showNextActivity(currentCourse);
+  }
+}
+
 document.addEventListener("DOMContentLoaded", () => {
+  currentCourse = getCourse ? getCourse() : '';
   startReconstruction();
   const open = document.getElementById("open-info");
   const close = document.getElementById("close-info");

--- a/argument-reconstruction/intro-philosophy.html
+++ b/argument-reconstruction/intro-philosophy.html
@@ -26,6 +26,7 @@
       </div>
       <button id="reconstruction-next" class="hidden" hidden>Next</button>
     </div>
+    <div id="summary" class="hidden" hidden></div>
   </div>
 
   <div id="info-modal" class="hidden" hidden>
@@ -38,6 +39,7 @@
   </div>
 
   <script src="intro-philosophy.js"></script>
+  <script src="../next-activity.js"></script>
   <script src="../page-header.js"></script>
 </body>
 </html>

--- a/argument-reconstruction/intro-philosophy.js
+++ b/argument-reconstruction/intro-philosophy.js
@@ -98,6 +98,8 @@ const reconstructionQuestions = [
 
 let reconstructionOrder = [];
 let reconstructionIndex = 0;
+let currentCourse = '';
+const MAX_QUESTIONS = 10;
 
 function shuffle(arr) {
   for (let i = arr.length - 1; i > 0; i--) {
@@ -109,6 +111,7 @@ function shuffle(arr) {
 function startReconstruction() {
   reconstructionOrder = reconstructionQuestions.slice();
   shuffle(reconstructionOrder);
+  reconstructionOrder = reconstructionOrder.slice(0, MAX_QUESTIONS);
   reconstructionIndex = 0;
   showReconstructionQuestion();
 }
@@ -181,15 +184,36 @@ function tryAgain() {
   controls.hidden = true;
 }
 
+function showSummary() {
+  const game = document.getElementById('reconstruction-game');
+  if (game) {
+    game.classList.add('hidden');
+    game.hidden = true;
+  }
+  const summary = document.getElementById('summary');
+  if (summary) {
+    summary.classList.remove('hidden');
+    summary.hidden = false;
+  }
+  if (typeof showNextActivity === 'function') {
+    showNextActivity(currentCourse);
+  }
+}
+
 document.getElementById("reconstruction-next").addEventListener("click", () => {
-  reconstructionIndex = (reconstructionIndex + 1) % reconstructionOrder.length;
-  showReconstructionQuestion();
+  reconstructionIndex++;
+  if (reconstructionIndex >= reconstructionOrder.length) {
+    showSummary();
+  } else {
+    showReconstructionQuestion();
+  }
 });
 
 document.getElementById("reconstruction-show-answer").addEventListener("click", showAnswer);
 document.getElementById("reconstruction-try-again").addEventListener("click", tryAgain);
 
 document.addEventListener("DOMContentLoaded", () => {
+  currentCourse = getCourse ? getCourse() : '';
   startReconstruction();
   const open = document.getElementById("open-info");
   const close = document.getElementById("close-info");


### PR DESCRIPTION
## Summary
- limit reconstruction activities to 10 random questions
- stop looping when questions end and show summary with next activity
- track course parameter using `getCourse`
- add summary placeholders and load `next-activity.js`

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6859ebfeadd08322b8b48bd1922cc69c