### PR TITLE
Add default course names to page headers

### DIFF
--- a/argument-reconstruction/critical-thinking.html
+++ b/argument-reconstruction/critical-thinking.html
@@ -10,7 +10,7 @@
   <nav id="top-nav">
     <a id="home-link" href="../index.html">Gaming Philosophy Class</a>
   </nav>
-  <header id="page-header">Course • Activity</header>
+  <header id="page-header" data-default-course="criticalThinking">Course • Activity</header>
   <div class="container">
     <h1>Arguments Activity</h1>
     <p>Fill in the missing premises to strengthen each argument. Select the best option from the list.</p>

--- a/argument-reconstruction/ethics.html
+++ b/argument-reconstruction/ethics.html
@@ -10,7 +10,7 @@
   <nav id="top-nav">
     <a id="home-link" href="../index.html">Gaming Philosophy Class</a>
   </nav>
-  <header id="page-header">Course • Activity</header>
+  <header id="page-header" data-default-course="ethics">Course • Activity</header>
   <div class="container">
     <h1>Arguments Activity</h1>
     <button id="open-info">Summary</button>

--- a/argument-reconstruction/intro-philosophy.html
+++ b/argument-reconstruction/intro-philosophy.html
@@ -10,7 +10,7 @@
   <nav id="top-nav">
     <a id="home-link" href="../index.html">Gaming Philosophy Class</a>
   </nav>
-  <header id="page-header">Course • Activity</header>
+  <header id="page-header" data-default-course="introPhilosophy">Course • Activity</header>
   <div class="container">
     <h1>Arguments Activity</h1>
     <p>Identify premises, argument types, and evaluations for classic philosophy topics.</p>

--- a/chatbots/ethics-chat.html
+++ b/chatbots/ethics-chat.html
@@ -10,7 +10,7 @@
   <nav id="top-nav">
     <a id="home-link" href="../index.html">Gaming Philosophy Class</a>
   </nav>
-  <header id="page-header">Course • Activity</header>
+  <header id="page-header" data-default-course="ethics">Course • Activity</header>
   <div class="container">
     <h1>Moral Theorists Group Chat</h1>
     <div id="chat-box"></div>

--- a/chatbots/intro-philosophy-chat.html
+++ b/chatbots/intro-philosophy-chat.html
@@ -10,7 +10,7 @@
   <nav id="top-nav">
     <a id="home-link" href="../index.html">Gaming Philosophy Class</a>
   </nav>
-  <header id="page-header">Course • Activity</header>
+  <header id="page-header" data-default-course="introPhilosophy">Course • Activity</header>
   <div class="container">
     <h1>Ancient Greek Philosophy Chat</h1>
     <div id="chat-box"></div>

--- a/debate-duel/debate-duel.html
+++ b/debate-duel/debate-duel.html
@@ -10,7 +10,7 @@
   <nav id="top-nav">
     <a id="home-link" href="../index.html">Gaming Philosophy Class</a>
   </nav>
-  <header id="page-header">Course • Activity</header>
+  <header id="page-header" data-default-course="criticalThinking">Course • Activity</header>
   <div class="container">
     <div id="intro">
       <h1>Debate Duel</h1>

--- a/flashcards/flashcards.html
+++ b/flashcards/flashcards.html
@@ -10,7 +10,7 @@
   <nav id="top-nav">
     <a id="home-link" href="../index.html">Gaming Philosophy Class</a>
   </nav>
-  <header id="page-header">Course • Activity</header>
+  <header id="page-header" data-default-course="introPhilosophy">Course • Activity</header>
   <div class="container">
     <h1>Flashcards</h1>
     <div>

--- a/jeopardy/index.html
+++ b/jeopardy/index.html
@@ -10,7 +10,7 @@
   <nav id="top-nav" aria-label="Main">
     <a id="home-link" href="../index.html">Gaming Philosophy Class</a>
   </nav>
-  <header id="page-header">Course • Activity</header>
+  <header id="page-header" data-default-course="introPhilosophy">Course • Activity</header>
 
   <main class="container">
     <a href="../index.html"><img id="site-icon" src="../icon.png" alt="Gaming Philosophy Class icon"></a>

--- a/page-header.js
+++ b/page-header.js
@@ -28,6 +28,9 @@ function loadHelpModal() {
 function updatePageHeader(courseKey) {
   const header = document.getElementById('page-header');
   if (!header) return;
+  if (!courseKey) {
+    courseKey = header.dataset.defaultCourse;
+  }
   const courseMap = {
     introPhilosophy: 'Intro to Philosophy',
     criticalThinking: 'Critical Thinking',
@@ -44,7 +47,11 @@ window.updatePageHeader = updatePageHeader;
 
 window.addEventListener('DOMContentLoaded', () => {
   const params = new URLSearchParams(window.location.search);
-  const courseKey = params.get('course');
+  const header = document.getElementById('page-header');
+  let courseKey = params.get('course');
+  if (!courseKey && header) {
+    courseKey = header.dataset.defaultCourse;
+  }
   const h1 = document.querySelector('.container h1');
   updatePageHeader(courseKey);
 

--- a/sherlock-mystery/sherlock.html
+++ b/sherlock-mystery/sherlock.html
@@ -10,7 +10,7 @@
   <nav id="top-nav">
     <a id="home-link" href="../index.html">Gaming Philosophy Class</a>
   </nav>
-  <header id="page-header">Course • Activity</header>
+  <header id="page-header" data-default-course="criticalThinking">Course • Activity</header>
   <div class="container">
     <h1>Sherlock Holmes Mystery</h1>
     <div id="intro-section">

--- a/timeline/timeline.html
+++ b/timeline/timeline.html
@@ -31,7 +31,7 @@
   <nav id="top-nav">
     <a id="home-link" href="../index.html">Gaming Philosophy Class</a>
   </nav>
-  <header id="page-header">Course • Activity</header>
+  <header id="page-header" data-default-course="introPhilosophy">Course • Activity</header>
   <div class="container">
     <h1>Interactive Timeline</h1>
     <div id="timeline-entry" tabindex="0">

--- a/trivia/trivia.html
+++ b/trivia/trivia.html
@@ -10,7 +10,7 @@
   <nav id="top-nav">
     <a id="home-link" href="../index.html">Gaming Philosophy Class</a>
   </nav>
-  <header id="page-header">Course • Activity</header>
+  <header id="page-header" data-default-course="introPhilosophy">Course • Activity</header>
   <div class="container">
     <h1>Trivia Game</h1>
     <div>

--- a/trolley/trolley.html
+++ b/trolley/trolley.html
@@ -19,7 +19,7 @@
   <nav id="top-nav">
     <a id="home-link" href="../index.html">Gaming Philosophy Class</a>
   </nav>
-  <header id="page-header">Course • Activity</header>
+  <header id="page-header" data-default-course="ethics">Course • Activity</header>
   <div class="container">
     <h1>Trolley Problem Simulator</h1>
     <div id="scenario">

--- a/writing/brainstorm.html
+++ b/writing/brainstorm.html
@@ -95,7 +95,7 @@
   <nav id="top-nav">
     <a id="home-link" href="../index.html">Gaming Philosophy Class</a>
   </nav>
-  <header id="page-header">Course • Activity</header>
+  <header id="page-header" data-default-course="writing">Course • Activity</header>
   <div class="container">
     <h1>Philosophical Mind Mapping</h1>
     <p class="instructions">Drag and drop the concepts below into logical clusters to brainstorm arguments against exceptionless moral rules.</p>

--- a/writing/citation-aid.html
+++ b/writing/citation-aid.html
@@ -10,7 +10,7 @@
   <nav id="top-nav">
     <a id="home-link" href="../index.html">Gaming Philosophy Class</a>
   </nav>
-  <header id="page-header">Course • Activity</header>
+  <header id="page-header" data-default-course="writing">Course • Activity</header>
   <div class="container">
     <h1>Citation Guide</h1>
     <p class="instructions">Consult this quick reference after completing the Citation Investigator.</p>

--- a/writing/citation.html
+++ b/writing/citation.html
@@ -10,7 +10,7 @@
   <nav id="top-nav">
     <a id="home-link" href="../index.html">Gaming Philosophy Class</a>
   </nav>
-  <header id="page-header">Course • Activity</header>
+  <header id="page-header" data-default-course="writing">Course • Activity</header>
   <div class="container">
     <h1>Citation Investigator</h1>
     <p class="instructions">Accurate citations help readers locate your sources, strengthen your credibility, and prevent plagiarism. Philosophical writing relies heavily on accurate referencing. Some prompts focus on MLA in-text citations (author and page), while others practice Works Cited formatting. Include the work’s title in the parenthetical only when you cite more than one work by the same author. This game follows MLA citation rules.</p>

--- a/writing/draft-development.html
+++ b/writing/draft-development.html
@@ -25,7 +25,7 @@
   <nav id="top-nav">
     <a id="home-link" href="../index.html">Gaming Philosophy Class</a>
   </nav>
-  <header id="page-header">Course • Activity</header>
+  <header id="page-header" data-default-course="writing">Course • Activity</header>
   <div class="container">
     <h1>Draft Development</h1>
     <section id="intro">

--- a/writing/index.html
+++ b/writing/index.html
@@ -10,7 +10,7 @@
   <nav id="top-nav">
     <a id="home-link" href="../index.html">Gaming Philosophy Class</a>
   </nav>
-  <header id="page-header">Course • Activity</header>
+  <header id="page-header" data-default-course="writing">Course • Activity</header>
   <div class="container">
     <h1>Writing Games</h1>
     <div class="game-links">

--- a/writing/outlining.html
+++ b/writing/outlining.html
@@ -56,7 +56,7 @@
   <nav id="top-nav">
     <a id="home-link" href="../index.html">Gaming Philosophy Class</a>
   </nav>
-  <header id="page-header">Course • Activity</header>
+  <header id="page-header" data-default-course="writing">Course • Activity</header>
   <div class="container">
     <h1>Outline Builder</h1>
     <p class="instructions">Drag each piece into any order you wish. Use the blank lines to add your own explanation and support for each claim.</p>

--- a/writing/peer-review.html
+++ b/writing/peer-review.html
@@ -10,7 +10,7 @@
   <nav id="top-nav">
     <a id="home-link" href="../index.html">Gaming Philosophy Class</a>
   </nav>
-  <header id="page-header">Course • Activity</header>
+  <header id="page-header" data-default-course="writing">Course • Activity</header>
   <div class="container">
     <h1>Peer Review Workshop</h1>
     <section id="intro">

--- a/writing/thesis-evaluation.html
+++ b/writing/thesis-evaluation.html
@@ -10,7 +10,7 @@
   <nav id="top-nav">
     <a id="home-link" href="../index.html">Gaming Philosophy Class</a>
   </nav>
-  <header id="page-header">Course • Activity</header>
+  <header id="page-header" data-default-course="writing">Course • Activity</header>
   <div class="container">
     <h1>Thesis Evaluation</h1>
     <p class="instructions">Welcome to Thesis Evaluation! Submit a thesis critiquing Kant's insistence on exceptionless moral rules.</p>

--- a/writing/writing.html
+++ b/writing/writing.html
@@ -10,7 +10,7 @@
   <nav id="top-nav">
     <a id="home-link" href="../index.html">Gaming Philosophy Class</a>
   </nav>
-  <header id="page-header">Course • Activity</header>
+  <header id="page-header" data-default-course="writing">Course • Activity</header>
   <div class="container">
     <h1>Writing in Philosophy</h1>
     <p>Practice key stages of philosophical writing through short activities. Each section includes instructions and examples labeled as "example provided" for comparison.</p>


### PR DESCRIPTION
## Summary
- set `data-default-course` on all course pages so a course name shows when no `?course` param is provided
- update `page-header.js` to use the default course if query param is absent

## Testing
- `git diff --name-only --cached`


------
https://chatgpt.com/codex/tasks/task_e_6859ec59d5c4832285425234372152db