### PR TITLE
Handle clipboard and share errors

### DIFF
--- a/jeopardy/script.js
+++ b/jeopardy/script.js
@@ -255,18 +255,26 @@ document.getElementById('scoreboard').addEventListener('click', (e) => {
 
 const copyBtn = document.getElementById('copy-link');
 if (copyBtn) {
-  copyBtn.addEventListener('click', () => {
-    navigator.clipboard.writeText(window.location.href);
+  copyBtn.addEventListener('click', async () => {
+    try {
+      await navigator.clipboard.writeText(window.location.href);
+    } catch (err) {
+      alert('Failed to copy link.');
+    }
   });
 }
 
 const shareBtn = document.getElementById('web-share');
 if (shareBtn) {
-  shareBtn.addEventListener('click', () => {
-    if (navigator.share) {
-      navigator.share({ url: window.location.href });
-    } else if (copyBtn) {
-      navigator.clipboard.writeText(window.location.href);
+  shareBtn.addEventListener('click', async () => {
+    try {
+      if (navigator.share) {
+        await navigator.share({ url: window.location.href });
+      } else if (copyBtn) {
+        await navigator.clipboard.writeText(window.location.href);
+      }
+    } catch (err) {
+      alert('Failed to share link.');
     }
   });
 }

--- a/trivia/trivia.js
+++ b/trivia/trivia.js
@@ -178,18 +178,26 @@ window.addEventListener('DOMContentLoaded', () => {
 
   const copy = document.getElementById('trivia-copy');
   if (copy) {
-    copy.addEventListener('click', () => {
-      navigator.clipboard.writeText(window.location.href);
+    copy.addEventListener('click', async () => {
+      try {
+        await navigator.clipboard.writeText(window.location.href);
+      } catch (err) {
+        alert('Failed to copy link.');
+      }
     });
   }
 
   const share = document.getElementById('trivia-web-share');
   if (share) {
-    share.addEventListener('click', () => {
-      if (navigator.share) {
-        navigator.share({ url: window.location.href });
-      } else if (copy) {
-        navigator.clipboard.writeText(window.location.href);
+    share.addEventListener('click', async () => {
+      try {
+        if (navigator.share) {
+          await navigator.share({ url: window.location.href });
+        } else if (copy) {
+          await navigator.clipboard.writeText(window.location.href);
+        }
+      } catch (err) {
+        alert('Failed to share link.');
       }
     });
   }


### PR DESCRIPTION
## Summary
- add try/catch when copying trivia links
- add try/catch when sharing trivia links
- wrap Jeopardy copy and share actions in try/catch blocks

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6859f2364dac8322bbcd2660d0e8b64d