### PR TITLE
Enhance trivia game UI

### DIFF
--- a/jeopardy/style.css
+++ b/jeopardy/style.css
@@ -428,6 +428,11 @@ button {
   font-size: 18px;
 }
 
+#trivia-score {
+  margin-top: 20px;
+  font-size: 18px;
+}
+
 #progress {
   height: 8px;
   background-color: #4caf50;

--- a/trivia/trivia.html
+++ b/trivia/trivia.html
@@ -21,6 +21,9 @@
       </select>
     </div>
 
+    <div id="trivia-score" class="hidden" hidden>Score: <span id="trivia-correct">0</span>/<span id="trivia-total">0</span></div>
+    <div class="course-progress"><div id="trivia-progress" class="course-progress-bar"></div></div>
+
     <div id="trivia-game" class="hidden" hidden tabindex="0">
       <p id="trivia-question"></p>
       <div id="trivia-options" class="mc-options"></div>

--- a/trivia/trivia.js
+++ b/trivia/trivia.js
@@ -37,7 +37,25 @@ let currentTrivia = [];
 let triviaIndex = 0;
 let optionIndex = 0;
 let questionsAnswered = 0;
+let correctCount = 0;
 let selectedCourse = '';
+
+function updateScore() {
+  const scoreEl = document.getElementById('trivia-score');
+  const correctEl = document.getElementById('trivia-correct');
+  const totalEl = document.getElementById('trivia-total');
+  if (scoreEl && correctEl && totalEl) {
+    correctEl.textContent = correctCount;
+    totalEl.textContent = currentTrivia.length;
+    scoreEl.classList.remove('hidden');
+    scoreEl.hidden = false;
+  }
+  const progress = document.getElementById('trivia-progress');
+  if (progress && currentTrivia.length > 0) {
+    const percent = (questionsAnswered / currentTrivia.length) * 100;
+    progress.style.width = `${percent}%`;
+  }
+}
 
 function populateCategories(course) {
   const catSelect = document.getElementById('category-select');
@@ -66,9 +84,11 @@ function loadTrivia(course, category = 'all') {
   shuffle(currentTrivia);
   triviaIndex = 0;
   questionsAnswered = 0;
+  correctCount = 0;
   const share = document.getElementById('trivia-share');
   if (share) share.classList.add('hidden');
   document.getElementById('trivia-game').classList.remove('hidden');   document.getElementById('trivia-game').hidden = false;
+  updateScore();
   showTriviaQuestion();
 }
 
@@ -85,6 +105,7 @@ function showTriviaQuestion() {
   if (!currentTrivia.length) return;
   const q = currentTrivia[triviaIndex];
   document.getElementById('trivia-question').innerText = q.question;
+  updateScore();
   const optionsDiv = document.getElementById('trivia-options');
   optionsDiv.innerHTML = '';
   const choices = buildChoices(q.answer);
@@ -107,6 +128,7 @@ function submitTrivia(choice) {
   if (choice === q.answer) {
     feedback.innerText = 'Correct!';
     feedback.style.color = '#4caf50';
+    correctCount++;
   } else {
     feedback.innerText = `Nope! The correct answer is ${q.answer}.`;
     feedback.style.color = '#c62828';
@@ -114,6 +136,7 @@ function submitTrivia(choice) {
   feedback.classList.remove('hidden');   feedback.hidden = false;
   document.getElementById('trivia-next').classList.remove('hidden');   document.getElementById('trivia-next').hidden = false;
   questionsAnswered++;
+  updateScore();
   if (questionsAnswered >= currentTrivia.length) {
     const share = document.getElementById('trivia-share');
     if (share) {


### PR DESCRIPTION
## Summary
- add score display and progress bar for trivia rounds
- style new scoreboard element
- show score and progress while answering

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6859f9834d7c8322b185a68fae80a004