### PR TITLE
Improve Debate Duel activity

### DIFF
--- a/debate-duel/debate-duel.html
+++ b/debate-duel/debate-duel.html
@@ -13,41 +13,51 @@
   </nav>
   <header id="page-header" data-default-course="criticalThinking">Course • Activity</header>
   <div class="container">
-    <div id="intro">
+    <div id="setup">
       <h1>Debate Duel</h1>
-      <p>Welcome to Debate Duel! In this interactive simulation, you'll practice critical thinking skills by engaging in structured debates. You'll choose responses, evaluate arguments, and avoid logical fallacies to out-debate your virtual opponent.</p>
-      <button id="start-btn">Start</button>
-    </div>
-    <div id="topic-select" class="hidden" hidden>
-      <h2>Select a Topic</h2>
-      <div class="game-links">
-        <button class="topic-btn" data-topic="A">Topic A: Should social media platforms regulate misinformation?</button>
-        <button class="topic-btn" data-topic="B">Topic B: Is artificial intelligence beneficial or dangerous?</button>
-        <button class="topic-btn" data-topic="C">Topic C: Should animal testing be banned in all circumstances?</button>
-        <button class="topic-btn" data-topic="D">Topic D: Should college education be tuition-free?</button>
+      <p class="instructions">Choose your stance and opponent to begin debating the topic below.</p>
+      <h2>Topic:</h2>
+      <p><em>"Social media improves public discourse."</em></p>
+      <div>
+        <label><input type="radio" name="stance" value="pro" checked> Pro</label>
+        <label><input type="radio" name="stance" value="con"> Con</label>
       </div>
+      <div style="margin-top:10px;">
+        <label><input type="radio" name="opponent" value="ai" checked> AI Opponent</label>
+        <label><input type="radio" name="opponent" value="human"> Human Opponent</label>
+      </div>
+      <button id="begin-btn">Begin Debate</button>
     </div>
+
     <div id="debate" class="hidden" hidden>
-      <h2 id="debate-title"></h2>
-      <p id="opponent"></p>
-      <div id="responses" class="mc-options"></div>
-      <p id="feedback" class="hidden" hidden></p>
-      <button id="next-round" class="hidden" hidden>Next</button>
+      <h2 id="round-label"></h2>
+      <p id="round-prompt"></p>
+      <textarea id="user-input" rows="3" style="width:90%;"></textarea><br>
+      <button id="submit-btn">Submit Statement</button>
+      <p id="opponent-response" class="hidden" hidden></p>
+      <div id="feedback" class="hidden" hidden></div>
+      <button id="next-round" class="hidden" hidden>Next Round</button>
+      <div class="course-progress"><div id="debate-progress" class="course-progress-bar"></div></div>
     </div>
-    <div id="summary" class="hidden" hidden>
+
+    <div id="score" class="hidden" hidden>
       <h2>Debate Completed!</h2>
-      <p id="summary-text"></p>
-      <section id="reflection">
-        <p>Which argument or response was the most challenging for you, and why?</p>
-        <textarea rows="3" style="width:90%;"></textarea>
-        <p>Did identifying logical fallacies help you improve your critical thinking? How?</p>
-        <textarea rows="3" style="width:90%;"></textarea>
-        <p>Describe a strategy you used successfully to construct strong, logical arguments.</p>
-        <textarea rows="3" style="width:90%;"></textarea>
-      </section>
+      <table id="score-table" style="margin:0 auto;text-align:left;"></table>
+      <button id="export-pdf">Export Transcript (PDF)</button>
+    </div>
+
+    <div id="reflection" class="hidden" hidden>
+      <h3>Reflection Questions</h3>
+      <p>After completing this debate, would you keep your original position, or change your mind? Explain why.</p>
+      <textarea rows="3" style="width:90%;"></textarea>
+      <p>Which argument was strongest from your opponent, and why?</p>
+      <textarea rows="3" style="width:90%;"></textarea>
+      <p>What could you have improved in your own argumentation?</p>
+      <textarea rows="3" style="width:90%;"></textarea>
     </div>
   </div>
   <script src="debate-duel.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
   <script src="../next-activity.js"></script>
   <script src="../page-header.js"></script>
 </body>

--- a/debate-duel/debate-duel.js
+++ b/debate-duel/debate-duel.js
@@ -1,155 +1,194 @@
-const topics = {
-  A: {
-    title: "Should social media platforms regulate misinformation?",
-    rounds: [
-      {
-        opponent: "Social media should never regulate misinformation because doing so violates free speech and opens the door to censorship.",
-        options: [
-          { text: "Protecting free speech is important, but allowing harmful misinformation like dangerous medical falsehoods can directly harm public health.", type: "strong", feedback: "Strong response! You've balanced free speech considerations with evidence of potential harm." },
-          { text: "You're wrong—regulation is always needed because people lie.", type: "weak", feedback: "Weak response: Your claim lacks clarity and evidence." },
-          { text: "So you're saying you support people lying and causing harm?", type: "fallacious", feedback: "Fallacious response: You've used a logical fallacy (strawman)—misrepresenting your opponent’s argument." }
-        ]
-      },
-      {
-        opponent: "But if we allow regulation, who decides what counts as misinformation? It risks becoming subjective and biased.",
-        options: [
-          { text: "You raise a valid concern about bias, which is why transparent guidelines and independent fact-checking standards are necessary.", type: "strong", feedback: "Strong response! You addressed the bias concern and proposed safeguards." },
-          { text: "Bias happens anyway, so we shouldn't worry too much.", type: "weak", feedback: "Weak response: This dismissal doesn't address the bias problem." },
-          { text: "If we don't regulate misinformation, society will completely collapse.", type: "fallacious", feedback: "Fallacious response: That's a slippery slope fallacy." }
-        ]
-      }
-    ]
+const rounds = [
+  {
+    label: 'Opening Statements',
+    prompt: 'Write a brief (2–3 sentences) opening statement clearly stating your position.'
   },
-  B: {
-    title: "Is artificial intelligence beneficial or dangerous?",
-    rounds: [
-      {
-        opponent: "AI is beneficial; it automates tedious tasks and enhances productivity.",
-        options: [
-          { text: "AI indeed provides benefits, but ignoring potential harms like job loss and biases can be dangerous. Balance is key.", type: "strong", feedback: "Strong response! You acknowledged benefits while highlighting potential harms." },
-          { text: "AI just takes away jobs; it’s bad.", type: "weak", feedback: "Weak response: It's vague and lacks supporting reasoning." },
-          { text: "Either AI saves the world or destroys humanity—there’s no middle ground.", type: "fallacious", feedback: "Fallacious response: This presents a false dilemma." }
-        ]
-      },
-      {
-        opponent: "But focusing on potential dangers could slow down innovation and economic growth.",
-        options: [
-          { text: "True, but responsible development explicitly addresses risks while still allowing progress.", type: "strong", feedback: "Strong response! You advocate balanced progress with risk management." },
-          { text: "Innovation matters more than anything.", type: "weak", feedback: "Weak response: This overlooks valid safety concerns." },
-          { text: "If we allow AI, it will inevitably wipe out humanity.", type: "fallacious", feedback: "Fallacious response: This is a slippery slope to extinction." }
-        ]
-      }
-    ]
+  {
+    label: 'Supporting Evidence',
+    prompt: 'Provide one specific example or credible piece of evidence supporting your position. Include a reference or source if possible.'
   },
-  C: {
-    title: "Should animal testing be banned in all circumstances?",
-    rounds: [
-      {
-        opponent: "Animal testing helps save human lives by enabling vital medical advances.",
-        options: [
-          { text: "Medical advances are important, but reducing unnecessary suffering by seeking alternatives wherever possible should be our goal.", type: "strong", feedback: "Strong response! You acknowledged benefits while proposing humane alternatives." },
-          { text: "Animal testing is cruel, end of story.", type: "weak", feedback: "Weak response: This ignores the reasoning about medical advances." },
-          { text: "Anyone supporting animal testing explicitly enjoys animal cruelty.", type: "fallacious", feedback: "Fallacious response: That's an appeal to emotion." }
-        ]
-      },
-      {
-        opponent: "Completely banning it could halt progress on lifesaving treatments.",
-        options: [
-          { text: "That's why many advocate tighter regulation and investment in alternatives rather than an outright ban.", type: "strong", feedback: "Strong response! You provide a balanced compromise." },
-          { text: "Progress will happen anyway.", type: "weak", feedback: "Weak response: This doesn't address the issue." },
-          { text: "If we ban testing, humanity will never cure diseases again.", type: "fallacious", feedback: "Fallacious response: That's a slippery slope." }
-        ]
-      }
-    ]
+  {
+    label: 'Rebuttal Round',
+    prompt: 'Directly respond to your opponent\u2019s previous claims. Clearly address their strongest argument.'
   },
-  D: {
-    title: "Should college education be tuition-free?",
-    rounds: [
-      {
-        opponent: "Tuition-free college places an unfair tax burden on people who don’t benefit from higher education.",
-        options: [
-          { text: "Your fairness concern is important, but investing in education benefits society through better employment, lower crime rates, and economic growth.", type: "strong", feedback: "Strong response! You address fairness while explaining societal benefits." },
-          { text: "Everyone should just pay taxes anyway; who cares?", type: "weak", feedback: "Weak response: This ignores the fairness objection." },
-          { text: "Only selfish people oppose tuition-free education.", type: "fallacious", feedback: "Fallacious response: That's an ad hominem." }
-        ]
-      },
-      {
-        opponent: "But how would we fund it without cutting other essential programs?",
-        options: [
-          { text: "We could explore a mix of progressive taxes and cost-sharing plans while carefully evaluating spending priorities.", type: "strong", feedback: "Strong response! You proposed constructive funding options." },
-          { text: "Funding isn't a big deal; money will appear.", type: "weak", feedback: "Weak response: This doesn't provide a realistic solution." },
-          { text: "If we don't make college free, the economy will collapse.", type: "fallacious", feedback: "Fallacious response: That's an exaggerated slippery slope." }
-        ]
-      }
-    ]
+  {
+    label: 'Closing Statements',
+    prompt: 'Summarize your key points succinctly, restating clearly why your position is stronger.'
   }
+];
+
+const aiResponses = {
+  pro: [
+    'Social media gives voice to marginalized communities, dramatically increasing diversity in public conversations.',
+    'According to Pew Research (2020), social media enables political engagement for 68% of users.',
+    'While misinformation exists, AI tools increasingly help reduce its spread significantly.',
+    'Despite challenges, social media ultimately provides essential platforms for diverse voices and public debate.'
+  ],
+  con: [
+    'Social media contributes heavily to misinformation, ultimately harming productive public dialogue.',
+    'Research indicates around 40% of misinformation spread on social media remains uncorrected (MIT, 2018).',
+    'AI moderation systems currently fail to identify nuanced misinformation consistently.',
+    'Social media\u2019s negative effects on discourse\u2014such as misinformation and polarization\u2014outweigh its benefits.'
+  ]
 };
 
-let currentTopic = null;
+let stance = 'pro';
+let opponent = 'ai';
 let roundIndex = 0;
-const counts = { strong: 0, weak: 0, fallacious: 0 };
+const transcript = [];
+const scores = { clarity: [], evidence: [], engagement: [], logic: [] };
 
-function showTopics() {
-  document.getElementById('intro').classList.add('hidden');   document.getElementById('intro').hidden = true;
-  document.getElementById('topic-select').classList.remove('hidden');   document.getElementById('topic-select').hidden = false;
-}
-
-function startTopic(key) {
-  currentTopic = topics[key];
-  roundIndex = 0;
-  counts.strong = counts.weak = counts.fallacious = 0;
-  document.getElementById('topic-select').classList.add('hidden');   document.getElementById('topic-select').hidden = true;
-  document.getElementById('debate-title').innerText = currentTopic.title;
-  document.getElementById('debate').classList.remove('hidden');   document.getElementById('debate').hidden = false;
+function startDebate() {
+  const stanceInput = document.querySelector('input[name="stance"]:checked');
+  const oppInput = document.querySelector('input[name="opponent"]:checked');
+  if (stanceInput) stance = stanceInput.value;
+  if (oppInput) opponent = oppInput.value;
+  document.getElementById('setup').classList.add('hidden');
+  document.getElementById('setup').hidden = true;
   showRound();
+  const debate = document.getElementById('debate');
+  debate.classList.remove('hidden');
+  debate.hidden = false;
 }
+
+document.getElementById('begin-btn').addEventListener('click', startDebate);
+
+document.getElementById('submit-btn').addEventListener('click', submitRound);
+
+document.getElementById('next-round').addEventListener('click', nextRound);
+
+document.getElementById('export-pdf').addEventListener('click', exportPdf);
 
 function showRound() {
-  const round = currentTopic.rounds[roundIndex];
-  document.getElementById('opponent').innerText = round.opponent;
-  const respDiv = document.getElementById('responses');
-  respDiv.innerHTML = '';
-  round.options.forEach(opt => {
-    const btn = document.createElement('button');
-    btn.className = 'option-btn';
-    btn.innerText = opt.text;
-    btn.onclick = () => chooseResponse(opt);
-    respDiv.appendChild(btn);
-  });
-  document.getElementById('feedback').classList.add('hidden');   document.getElementById('feedback').hidden = true;
-  document.getElementById('next-round').classList.add('hidden');   document.getElementById('next-round').hidden = true;
+  const r = rounds[roundIndex];
+  document.getElementById('round-label').innerText = r.label;
+  document.getElementById('round-prompt').innerText = r.prompt;
+  document.getElementById('user-input').value = '';
+  hideElement('opponent-response');
+  hideElement('feedback');
+  hideElement('next-round');
+  updateProgress();
 }
 
-function chooseResponse(option) {
-  counts[option.type]++;
-  const fb = document.getElementById('feedback');
-  fb.innerText = option.feedback;
-  fb.style.color = option.type === 'strong' ? '#4caf50' : option.type === 'weak' ? '#ff9800' : '#c62828';
-  fb.classList.remove('hidden');   fb.hidden = false;
-  document.getElementById('next-round').classList.remove('hidden');   document.getElementById('next-round').hidden = false;
+function submitRound() {
+  const input = document.getElementById('user-input');
+  const text = input.value.trim();
+  if (!text) return;
+  let opp = '';
+  if (opponent === 'ai') {
+    const arr = stance === 'pro' ? aiResponses.con : aiResponses.pro;
+    opp = arr[roundIndex] || '';
+  } else {
+    opp = prompt('Opponent response:') || '';
+  }
+  const oppEl = document.getElementById('opponent-response');
+  oppEl.innerText = opp;
+  showElement('opponent-response');
+
+  const fb = generateFeedback(text, opp);
+  displayFeedback(fb);
+  transcript.push({ label: rounds[roundIndex].label, user: text, opponent: opp, feedback: fb });
+
+  showElement('next-round');
+}
+
+function generateFeedback(text, opp) {
+  const clarity = text.length > 30 ? 4 : 2;
+  const evidence = /(\d|study|research|because|for example|according)/i.test(text) ? 4 : 2;
+  const engagement = opp && /(you|your|opponent|they)/i.test(text) ? 4 : 2;
+  const logic = /(therefore|thus|hence|because|since)/i.test(text) ? 4 : 2;
+  scores.clarity.push(clarity);
+  scores.evidence.push(evidence);
+  scores.engagement.push(engagement);
+  scores.logic.push(logic);
+  return { clarity, evidence, engagement, logic };
+}
+
+function feedbackLine(label, val) {
+  return val >= 4 ? `${label}: Excellent!` : val >= 3 ? `${label}: Good.` : `${label}: Needs improvement.`;
+}
+
+function displayFeedback(fb) {
+  const lines = [
+    feedbackLine('Claim Clarity', fb.clarity),
+    feedbackLine('Use of Evidence', fb.evidence),
+    feedbackLine('Engagement', fb.engagement),
+    feedbackLine('Logic and Coherence', fb.logic)
+  ];
+  const div = document.getElementById('feedback');
+  div.innerHTML = lines.join('<br>');
+  showElement('feedback');
 }
 
 function nextRound() {
   roundIndex++;
-  if (roundIndex < currentTopic.rounds.length) {
+  if (roundIndex < rounds.length) {
     showRound();
   } else {
-    showSummary();
+    showScore();
   }
 }
 
-function showSummary() {
-  document.getElementById('debate').classList.add('hidden');   document.getElementById('debate').hidden = true;
-  const text = `You chose strong arguments: ${counts.strong}/2\n` +
-               `You chose weak arguments: ${counts.weak}/2\n` +
-               `Logical fallacies used: ${counts.fallacious}`;
-  document.getElementById('summary-text').innerText = text;
-  document.getElementById('summary').classList.remove('hidden');   document.getElementById('summary').hidden = false;
+function updateProgress() {
+  const percent = (roundIndex / rounds.length) * 100;
+  document.getElementById('debate-progress').style.width = `${percent}%`;
+}
+
+function showScore() {
+  hideElement('debate');
+  const table = document.getElementById('score-table');
+  table.innerHTML = '';
+  const head = document.createElement('tr');
+  head.innerHTML = '<th>Category</th><th>Points</th>';
+  table.appendChild(head);
+  const totals = {};
+  ['clarity','evidence','engagement','logic'].forEach(k => {
+    const avg = Math.round(scores[k].reduce((a,b)=>a+b,0) / scores[k].length);
+    totals[k] = avg;
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${k.charAt(0).toUpperCase()+k.slice(1)}</td><td>${avg}</td>`;
+    table.appendChild(tr);
+  });
+  const totalPoints = Object.values(totals).reduce((a,b)=>a+b,0);
+  const trTotal = document.createElement('tr');
+  trTotal.innerHTML = `<td>Total</td><td>${totalPoints}</td>`;
+  table.appendChild(trTotal);
+  showElement('score');
+  showElement('reflection');
+  updateProgress();
   showNextActivity('criticalThinking');
 }
 
-document.getElementById('start-btn').addEventListener('click', showTopics);
-document.querySelectorAll('.topic-btn').forEach(btn => {
-  btn.addEventListener('click', () => startTopic(btn.dataset.topic));
+function exportPdf() {
+  const { jsPDF } = window.jspdf;
+  const doc = new jsPDF();
+  let y = 10;
+  doc.text('Debate Transcript', 10, y); y += 10;
+  transcript.forEach(item => {
+    doc.text(item.label, 10, y); y += 6;
+    doc.text('You: ' + item.user, 10, y); y += 6;
+    doc.text('Opponent: ' + item.opponent, 10, y); y += 8;
+  });
+  doc.text('Scores:', 10, y); y += 6;
+  ['clarity','evidence','engagement','logic'].forEach(k => {
+    const avg = Math.round(scores[k].reduce((a,b)=>a+b,0) / scores[k].length);
+    doc.text(`${k}: ${avg}`, 10, y); y += 6;
+  });
+  doc.save('debate.pdf');
+}
+
+function hideElement(id) {
+  const el = document.getElementById(id);
+  el.classList.add('hidden');
+  el.hidden = true;
+}
+
+function showElement(id) {
+  const el = document.getElementById(id);
+  el.classList.remove('hidden');
+  el.hidden = false;
+}
+
+window.addEventListener('DOMContentLoaded', () => {
+  updateProgress();
 });
-document.getElementById('next-round').addEventListener('click', nextRound);


### PR DESCRIPTION
## Summary
- redesign Debate Duel page to set stance and opponent
- implement interactive debate rounds with prompts, progress bar and scoring
- show AI feedback for each round and export transcript

## Testing
- `node --check debate-duel/debate-duel.js`

------
https://chatgpt.com/codex/tasks/task_e_6859fcddf1448322b9e21905cb4363e5