### PR TITLE
Fix flashcard card height layout

### DIFF
--- a/jeopardy/style.css
+++ b/jeopardy/style.css
@@ -889,8 +889,9 @@ button {
   overflow-y: auto;
   display: flex;
   flex-direction: column;
-  justify-content: center;
-  align-items: center;
+  /* allow content area to fill the card height */
+  justify-content: flex-start;
+  align-items: stretch;
   text-align: center;
 }
 
@@ -919,6 +920,10 @@ button {
 #flashcard-answer {
   /* Slightly larger text for better readability */
   font-size: 1.4em;
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 #trivia-game,


### PR DESCRIPTION
## Summary
- allow the flip card content area to stretch to full height
- let question and answer text fill the remaining card space so blank areas go away

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6859ff129e3c8322b8b8d3e137a38186