### PR TITLE
Fix flashcard content layout

### DIFF
--- a/flashcards/flashcards.html
+++ b/flashcards/flashcards.html
@@ -26,7 +26,9 @@
         <div class="flip-card-inner">
           <div class="flip-card-front">
             <button class="flashcard-close" type="button">X</button>
-            <p id="flashcard-question"></p>
+            <div class="flashcard-content">
+              <p id="flashcard-question"></p>
+            </div>
             <div class="flashcard-controls">
               <button class="prev-card">Prev Card</button>
               <button class="next-card">Next Card</button>
@@ -34,7 +36,9 @@
           </div>
           <div class="flip-card-back">
             <button class="flashcard-close" type="button">X</button>
-            <p id="flashcard-answer" class="hidden" hidden></p>
+            <div class="flashcard-content">
+              <p id="flashcard-answer" class="hidden" hidden></p>
+            </div>
             <div class="flashcard-controls">
               <button class="prev-card">Prev Card</button>
               <button class="next-card">Next Card</button>

--- a/jeopardy/style.css
+++ b/jeopardy/style.css
@@ -920,10 +920,6 @@ button {
 #flashcard-answer {
   /* Slightly larger text for better readability */
   font-size: 1.4em;
-  flex: 1;
-  display: flex;
-  align-items: center;
-  justify-content: center;
 }
 
 #trivia-game,
@@ -944,6 +940,13 @@ button {
   top: 8px;
   right: 8px;
   z-index: 2;
+}
+
+.flashcard-content {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .flashcard-controls {


### PR DESCRIPTION
## Summary
- wrap flashcard question/answer in `.flashcard-content` containers
- center content with new `.flashcard-content` style
- simplify `#flashcard-question` and `#flashcard-answer` rules

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685a0183d5488322b235cb517e9b5e4f