### PR TITLE
Move flashcard higher on page

### DIFF
--- a/flashcards/flashcards.html
+++ b/flashcards/flashcards.html
@@ -8,7 +8,7 @@
   <link rel="stylesheet" href="style.css">
   <link rel="icon" href="../favicon.png" type="image/png">
 </head>
-<body>
+<body class="flashcard-page">
   <nav id="top-nav">
     <a id="home-link" href="../index.html">Gaming Philosophy Class</a>
   </nav>

--- a/flashcards/style.css
+++ b/flashcards/style.css
@@ -24,3 +24,8 @@
 .flip-card {
   cursor: pointer;
 }
+
+body.flashcard-page .container {
+  /* Add space below the fixed navbar without pushing content too far down */
+  margin-top: 60px;
+}


### PR DESCRIPTION
## Summary
- adjust top margin of flashcards page
- mark flashcards page with a class to apply the styling
- tweak margin to avoid layout overlap

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_685a09677294832281a24a6a8ed2f43d