### PR TITLE
Make timeline end year dynamic

### DIFF
--- a/timeline/timeline.js
+++ b/timeline/timeline.js
@@ -1,5 +1,10 @@
 const timelineStart = -650;
-const timelineEnd = 2025;
+let timelineEnd = new Date().getFullYear();
+if (typeof window !== 'undefined') {
+  const params = new URLSearchParams(window.location.search);
+  const p = parseInt(params.get('endYear'), 10);
+  if (!isNaN(p)) timelineEnd = p;
+}
 
 const philosophyTimeline = [
   {


### PR DESCRIPTION
## Summary
- make the end year of the philosophy timeline configurable via the `endYear` URL parameter
- compute timeline labels with the chosen year

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685a0f77a1248322bda01b8e428b3e67