### PR TITLE
Enhance Bullshit Detector activity with new examples and fact check

### DIFF
--- a/writing/ai-evaluation.html
+++ b/writing/ai-evaluation.html
@@ -44,7 +44,18 @@
       <button id="br-btn">Brilliant</button>
       <div id="bs-feedback" class="hidden" hidden></div>
       <button id="bs-next" class="hidden" hidden>Next Example</button>
-      <button id="bs-finish" class="next-btn hidden" data-next="environment" hidden>Continue</button>
+      <button id="bs-finish" class="next-btn hidden" data-next="fact-reminder" hidden>Continue</button>
+    </section>
+
+    <section id="fact-reminder" class="hidden" hidden>
+      <h3>Important Reminder</h3>
+      <p>AI tools sometimes generate inaccurate or unclear text. Always verify your facts, references, and claims carefully against reliable sources to avoid unintentional misinformation (philosophically called 'bullshit'). Good philosophy requires explicitly accurate and meaningful arguments.</p>
+      <h4>Fact Verification Practice:</h4>
+      <p>AI-generated claim: 'Kant says lying is morally permissible to save innocent lives.'</p>
+      <button id="verify-true">True</button>
+      <button id="verify-false">False</button>
+      <div id="verify-feedback" class="hidden" hidden></div>
+      <button id="verify-next" class="next-btn hidden" data-next="environment" hidden>Continue</button>
     </section>
 
     <section id="environment" class="hidden" hidden>

--- a/writing/ai-evaluation.js
+++ b/writing/ai-evaluation.js
@@ -1,4 +1,4 @@
-const sections = ['intro','case-study','bullshit-game','environment','reflection'];
+const sections = ['intro','case-study','bullshit-game','fact-reminder','environment','reflection'];
 
 function showSection(id) {
   sections.forEach(sec => {
@@ -40,8 +40,13 @@ document.getElementById('choose-a').addEventListener('click', () => chooseCase('
 document.getElementById('choose-b').addEventListener('click', () => chooseCase('B'));
 
 const bsExamples = [
-  { text: 'Ethical imperatives juxtapose against relativistic tendencies, manifesting intricate socio-cultural dichotomies.', correct: 'bullshit' },
-  { text: "Kant's moral absolutism does not sufficiently consider context, causing problems in complex situations like lying to protect innocent people.", correct: 'brilliant' }
+  { text: 'Ethical imperatives juxtapose against relativistic tendencies, manifesting intricate socio-cultural dichotomies.', correct: 'bullshit', feedback: 'Bullshit! \uD83D\uDEA9 This sentence tries to sound deep but says nothing concrete.' },
+  { text: "Kant's moral absolutism does not sufficiently consider context, causing problems in complex situations like lying to protect innocent people.", correct: 'brilliant', feedback: 'Brilliant! \u2705 Clear and provides a meaningful critique of Kant.' },
+  { text: 'Morality profoundly and existentially shapes societal fabric through universally resonant paradigms.', correct: 'bullshit', feedback: "Bullshit! \uD83D\uDEA9 This example is vague, uses overly complicated language, and has no clear meaning. Always prefer precise, meaningful language in your writing." },
+  { text: 'References (Example Only—Replace with Real References): Smith, J. (year). Title.', correct: 'bullshit', feedback: "Bullshit! \uD83D\uDEA9 Placeholder references indicate no actual verification or research. Always replace these with verified, real citations." },
+  { text: "Kant's ethics insists on duty-based morality. According to Smith (2022) about gardening techniques, regular watering schedules are important.", correct: 'bullshit', feedback: "Bullshit! \uD83D\uDEA9 The cited source (about gardening) is completely irrelevant. Always check that your references are directly related and meaningful." },
+  { text: 'Kant argues lying is always morally wrong, even to save innocent lives (Kant, 1797/1996, p. 552).', correct: 'brilliant', feedback: 'Brilliant! \u2705 This is a clear, precise statement supported by a verified, correctly cited source.' },
+  { text: 'Virtue ethics emphasizes practical wisdom (phronesis), helping individuals respond appropriately in diverse situations (Aristotle, 350 BCE/2009).', correct: 'brilliant', feedback: 'Brilliant! \u2705 Clearly written, specific, and properly referenced—exactly what makes writing credible.' }
 ];
 let bsIndex = 0;
 
@@ -60,7 +65,7 @@ function answerBS(choice) {
   const example = bsExamples[bsIndex];
   const fb = document.getElementById('bs-feedback');
   if (choice === example.correct) {
-    fb.innerText = choice === 'bullshit' ? '🎉 Bullshit Detected! Nice catch!' : '🎉 Correct!';
+    fb.innerText = example.feedback;
   } else {
     fb.innerText = '❌ Tricky one! Remember, clarity and meaningful detail matter most.';
   }
@@ -86,6 +91,23 @@ document.getElementById('bs-next').addEventListener('click', () => {
     showBS();
   }
 });
+
+function verifyAnswer(ans) {
+  const fb = document.getElementById('verify-feedback');
+  if (ans === 'false') {
+    fb.innerText = 'Correct! \u2705 Kant indeed insists lying is never permissible. Always verify AI-generated statements carefully to avoid misinformation.';
+  } else {
+    fb.innerText = 'Incorrect! \uD83D\uDEA9 Kant explicitly argues lying is never permissible, even to save lives (Kant, 1797/1996). Always carefully verify philosophical claims against original sources.';
+  }
+  fb.classList.remove('hidden');
+  fb.hidden = false;
+  const nxt = document.getElementById('verify-next');
+  nxt.classList.remove('hidden');
+  nxt.hidden = false;
+}
+
+document.getElementById('verify-true').addEventListener('click', () => verifyAnswer('true'));
+document.getElementById('verify-false').addEventListener('click', () => verifyAnswer('false'));
 
 const envButtons = document.querySelectorAll('.env-btn');
 envButtons.forEach(btn => {


### PR DESCRIPTION
## Summary
- insert additional bullshit/brilliant examples in `ai-evaluation.js`
- show detailed feedback strings for each example
- add reminder and fact verification practice in `ai-evaluation.html`
- hook up verification question logic in `ai-evaluation.js`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685a10410de083229d7d7092c9a09423