### PR TITLE
Add learning outcomes section to activity pages

### DIFF
--- a/argument-reconstruction/critical-thinking.html
+++ b/argument-reconstruction/critical-thinking.html
@@ -39,6 +39,13 @@
     </div>
   </div>
 
+  <script>
+    window.activityOutcomes = [
+      'Spot missing premises in informal arguments about everyday reasoning.',
+      'Compare multiple reconstructions to see which best secures the conclusion.',
+      'Reference the provided explanations and sources to justify your choice.'
+    ];
+  </script>
   <script src="../utils.js"></script>
   <script src="critical-thinking.js"></script>
   <script src="../next-activity.js"></script>

--- a/argument-reconstruction/ethics.html
+++ b/argument-reconstruction/ethics.html
@@ -40,6 +40,13 @@
     </div>
   </div>
 
+  <script>
+    window.activityOutcomes = [
+      'Reconstruct core moves in consequentialist, deontological, and virtue ethics debates.',
+      'Match each ethical scenario with the premise that secures the featured theory’s verdict.',
+      'Cite the accompanying explanations and texts when defending your chosen reconstruction.'
+    ];
+  </script>
   <script src="../utils.js"></script>
   <script src="ethics.js"></script>
   <script src="../next-activity.js"></script>

--- a/argument-reconstruction/intro-philosophy.html
+++ b/argument-reconstruction/intro-philosophy.html
@@ -39,6 +39,13 @@
     </div>
   </div>
 
+  <script>
+    window.activityOutcomes = [
+      'Rebuild landmark intro philosophy arguments from missing-premise prompts.',
+      'Differentiate competing positions by selecting the premise that makes the reasoning valid.',
+      'Anchor each reconstruction in the supplied explanation and primary-source citation.'
+    ];
+  </script>
   <script src="../utils.js"></script>
   <script src="intro-philosophy.js"></script>
   <script src="../next-activity.js"></script>

--- a/argument-reconstruction/logic.html
+++ b/argument-reconstruction/logic.html
@@ -38,6 +38,13 @@
     </div>
   </div>
 
+  <script>
+    window.activityOutcomes = [
+      'Translate everyday arguments into premise-conclusion form for logic practice.',
+      'Classify each argument’s strength by weighing validity, soundness, and cogency options.',
+      'Use the detailed explanations and citations to reinforce correct evaluations.'
+    ];
+  </script>
   <script src="../utils.js"></script>
   <script src="logic.js"></script>
   <script src="../next-activity.js"></script>

--- a/chatbots/ethics-chat.html
+++ b/chatbots/ethics-chat.html
@@ -24,6 +24,13 @@
     </div>
     <div id="chat-controls"></div>
   </div>
+  <script>
+    window.activityOutcomes = [
+      'Compare how major moral theories approach contemporary dilemmas.',
+      'Practice charitable listening and targeted follow-up questions with each persona.',
+      'Collect quotable explanations and references for use in debates or essays.'
+    ];
+  </script>
   <script src="ethical-chatbot.js"></script>
   <script src="ethics-chat-engine.js"></script>
   <script src="../explain.js"></script>

--- a/chatbots/intro-philosophy-chat.html
+++ b/chatbots/intro-philosophy-chat.html
@@ -24,6 +24,13 @@
     </div>
     <div id="chat-controls"></div>
   </div>
+  <script>
+    window.activityOutcomes = [
+      'Interview ancient philosophers to surface their core theses and arguments.',
+      'Practice summarizing and challenging positions using the guided persona prompts.',
+      'Capture citations from the chat log to support later explanations and write-ups.'
+    ];
+  </script>
   <script src="intro-philosophy-chatbot-revised.js"></script>
   <script src="../explain.js"></script>
   <script src="../keyterms-sidebar.js"></script>

--- a/flashcards/flashcards.html
+++ b/flashcards/flashcards.html
@@ -47,6 +47,13 @@
     </div>
   </div>
 
+  <script>
+    window.activityOutcomes = [
+      'Cycle through key terms and definitions for each philosophy unit.',
+      'Practice active recall by flipping cards and tracking tricky concepts.',
+      'Connect every flashcard to its explanation and source for deeper review.'
+    ];
+  </script>
   <script src="../jeopardy/data/intro-philosophy-flashcards.js"></script>
   <script src="../jeopardy/data/critical-thinking-flashcards.js"></script>
   <script src="../jeopardy/data/ethics-flashcards.js"></script>

--- a/jeopardy/index.html
+++ b/jeopardy/index.html
@@ -22,6 +22,7 @@
   <header id="page-header" data-default-course="introPhilosophy">Course • Activity</header>
 
   <main class="container">
+    <h1>Jeopardy Review Hub</h1>
     <p id="instructions">Pick a course to explore flashcards, trivia, and a game board. Play solo or with friends.</p>
     <div id="topic-selector">
       <div class="course">
@@ -151,6 +152,13 @@
 
   <footer class="site-footer">&copy; <a href="https://www.maparks.com">maxaeon</a> 2025</footer>
 
+  <script>
+    window.activityOutcomes = [
+      'Survey the activity formats available for each philosophy course track.',
+      'Jump into Jeopardy boards that align with current lecture units or exams.',
+      'Pair the game board with flashcards, trivia, and chats for spaced review.'
+    ];
+  </script>
   <script src="data/ethics.js"></script>
   <script src="data/ethics-final.js"></script>
   <script src="data/critical-thinking.js"></script>

--- a/page-header.js
+++ b/page-header.js
@@ -102,6 +102,76 @@ function updatePageHeader(courseKey) {
 
 window.updatePageHeader = updatePageHeader;
 
+function ensureOutcomesStyles() {
+  if (document.getElementById('outcome-style')) return;
+  const style = document.createElement('style');
+  style.id = 'outcome-style';
+  style.textContent = `
+    #outcomes.learning-outcomes {
+      margin-top: 0.5rem;
+      padding: 0.5rem 0;
+      font-size: 0.9em;
+      color: var(--outcome-text, #555);
+    }
+    #outcomes.learning-outcomes h2 {
+      font-size: 1em;
+      margin: 0 0 0.25rem;
+      color: inherit;
+      font-weight: 600;
+    }
+    #outcomes.learning-outcomes ul {
+      margin: 0;
+      padding-left: 1.25rem;
+    }
+    #outcomes.learning-outcomes li {
+      margin-bottom: 0.25rem;
+      line-height: 1.4;
+    }
+  `;
+  document.head.appendChild(style);
+}
+
+function renderOutcomes() {
+  const container = document.querySelector('.container, main, body');
+  const heading = container ? container.querySelector('h1') : document.querySelector('h1');
+  if (!heading) return;
+  let section = document.getElementById('outcomes');
+  if (!section) {
+    section = document.createElement('section');
+    section.id = 'outcomes';
+    section.className = 'learning-outcomes';
+    section.setAttribute('aria-labelledby', 'outcomes-heading');
+    section.hidden = true;
+    section.innerHTML = '<h2 id="outcomes-heading">Learning outcomes</h2>';
+    heading.insertAdjacentElement('afterend', section);
+  }
+  const outcomes = Array.isArray(window.activityOutcomes) ? window.activityOutcomes : [];
+  const list = document.createElement('ul');
+  list.className = 'outcome-items';
+  outcomes.forEach(item => {
+    const li = document.createElement('li');
+    li.textContent = item;
+    list.appendChild(li);
+  });
+  const existingList = section.querySelector('ul');
+  if (existingList) existingList.remove();
+  if (outcomes.length) {
+    section.appendChild(list);
+    section.hidden = false;
+    section.removeAttribute('aria-hidden');
+  } else {
+    section.hidden = true;
+    section.setAttribute('aria-hidden', 'true');
+  }
+}
+
+window.renderActivityOutcomes = function(outcomes) {
+  if (Array.isArray(outcomes)) {
+    window.activityOutcomes = outcomes;
+    renderOutcomes();
+  }
+};
+
 function addSkipLink() {
   const link = document.createElement('a');
   link.href = '#main';
@@ -126,12 +196,13 @@ function initPageHeader() {
   if (!courseKey && header) {
     courseKey = header.dataset.defaultCourse;
   }
-  const h1 = document.querySelector('.container h1');
   applyCourseColor(courseKey);
   updatePageHeader(courseKey);
 
   ensureMainId();
   addSkipLink();
+  ensureOutcomesStyles();
+  renderOutcomes();
 
   loadHelpModal();
   createCourseSidebar();

--- a/prover/prover.html
+++ b/prover/prover.html
@@ -77,6 +77,13 @@
     </section>
     <div id="summary" class="hidden" hidden></div>
   </div>
+  <script>
+    window.activityOutcomes = [
+      'Practice core natural deduction moves with guided reveal prompts.',
+      'Build full derivations using tile banks, multiple-choice checks, and modal examples.',
+      'Lean on explanations and cited rule glosses to justify each proof step.'
+    ];
+  </script>
   <script src="../utils.js"></script>
   <script src="prover.js"></script>
   <script src="../next-activity.js"></script>

--- a/sherlock-mystery/sherlock.html
+++ b/sherlock-mystery/sherlock.html
@@ -24,6 +24,13 @@
     </div>
     <div id="chat-controls"></div>
   </div>
+  <script>
+    window.activityOutcomes = [
+      'Trace abductive inferences alongside Holmes and Watson during the case.',
+      'Ask clarifying questions that distinguish evidence, hypotheses, and background assumptions.',
+      'Document explanations and cited clues to support the final solution write-up.'
+    ];
+  </script>
   <script src="sherlock-chat.js"></script>
   <script src="../explain.js"></script>
   <script src="../keyterms-sidebar.js"></script>

--- a/trivia/trivia.html
+++ b/trivia/trivia.html
@@ -36,7 +36,13 @@
       <button id="trivia-web-share">Share</button>
     </div>
   </div>
-
+  <script>
+    window.activityOutcomes = [
+      'Sharpen rapid-fire recall across the philosophy curriculum.',
+      'Diagnose which difficulty tiers and topics need more review time.',
+      'Study explanations and cited sources after each answer reveal.'
+    ];
+  </script>
   <script src="../jeopardy/data/ethics.js"></script>
   <script src="../jeopardy/data/ethics-final.js"></script>
   <script src="../jeopardy/data/critical-thinking.js"></script>

--- a/trolley/trolley.html
+++ b/trolley/trolley.html
@@ -38,6 +38,13 @@
     </div>
     <div id="summary" class="hidden" hidden></div>
   </div>
+  <script>
+    window.activityOutcomes = [
+      'Contrast utilitarian and deontological responses to classic trolley variants.',
+      'Reflect on how minor scenario tweaks shift moral intuitions and principles.',
+      'Record explanations and sources that justify each decision you endorse.'
+    ];
+  </script>
   <script src="trolley.js"></script>
   <script src="../next-activity.js"></script>
   <script src="../explain.js"></script>

--- a/truth-tables/symbolization.html
+++ b/truth-tables/symbolization.html
@@ -82,6 +82,13 @@
 
     <button id="start-tables">Continue to Truth Tables</button>
   </div>
+  <script>
+    window.activityOutcomes = [
+      'Refresh the semantics of each connective using reference truth tables.',
+      'Translate natural-language claims into symbolic notation with immediate feedback.',
+      'Carry forward symbolization skills into full truth-table analysis with cited examples.'
+    ];
+  </script>
   <script src="truth-tables.js"></script>
   <script src="../next-activity.js"></script>
   <script src="../keyterms-sidebar.js"></script>

--- a/truth-tables/truth-tables.html
+++ b/truth-tables/truth-tables.html
@@ -22,6 +22,13 @@
     <div id="validity" class="tt-section"></div>
     <button id="back-symbolization">Back to Symbolization</button>
   </div>
+  <script>
+    window.activityOutcomes = [
+      'Construct full truth tables for compound statements across multiple connectives.',
+      'Diagnose tautologies, contradictions, and contingencies through completed rows.',
+      'Assess argument validity by interpreting explanations tied to key counterexamples.'
+    ];
+  </script>
   <script src="truth-tables.js"></script>
   <script src="../next-activity.js"></script>
   <script src="../keyterms-sidebar.js"></script>

--- a/writing/ai-evaluation.html
+++ b/writing/ai-evaluation.html
@@ -80,6 +80,13 @@
       </ul>
     </section>
   </div>
+  <script>
+    window.activityOutcomes = [
+      'Evaluate AI-generated prose using Frankfurt’s bullshit test and writing criteria.',
+      'Practice verifying factual claims and citations that automated tools may fabricate.',
+      'Decide when AI support aligns with ethical, environmental, and scholarly standards.'
+    ];
+  </script>
   <script src="ai-evaluation.js"></script>
   <script src="../explain.js"></script>
   <script src="../keyterms-sidebar.js"></script>

--- a/writing/brainstorm.html
+++ b/writing/brainstorm.html
@@ -117,6 +117,13 @@
     <button id="export-pdf">Export as PDF</button>
     <button id="clear-map">Clear Map</button>
   </div>
+  <script>
+    window.activityOutcomes = [
+      'Generate and organize concept clusters for upcoming philosophy essays.',
+      'Visualize connections among objections, replies, and sources in one workspace.',
+      'Export brainstorm maps with annotations that inform outlines and drafts.'
+    ];
+  </script>
   <script src="brainstorm.js"></script>
   <script src="../vendor/html2canvas.min.js"></script>
   <script src="../vendor/jspdf.umd.min.js"></script>

--- a/writing/citation-aid.html
+++ b/writing/citation-aid.html
@@ -62,6 +62,13 @@ Aristotle argues virtue is a mean (<em>Nicomachean Ethics</em> 1107b).
       <button onclick="location.href='citation.html'">Return to Source Savvy</button>
     </section>
   </div>
+  <script>
+    window.activityOutcomes = [
+      'Consult quick MLA models while revising drafts or completing the citation activity.',
+      'Differentiate between correct and problematic in-text and Works Cited formatting.',
+      'Bookmark vetted external resources for ongoing research and source management.'
+    ];
+  </script>
   <script src="../explain.js"></script>
   <script src="../keyterms-sidebar.js"></script>
   <script src="../page-header.js"></script>

--- a/writing/citation.html
+++ b/writing/citation.html
@@ -96,6 +96,13 @@ Kant writes that one must never lie (31).
       </div>
     </section>
   </div>
+  <script>
+    window.activityOutcomes = [
+      'Verify philosophical claims before citing them in papers or presentations.',
+      'Diagnose and correct MLA in-text and Works Cited formatting issues.',
+      'Collect model citations and explanations to reference during future assignments.'
+    ];
+  </script>
   <script src="citation.js"></script>
   <script src="../explain.js"></script>
   <script src="../keyterms-sidebar.js"></script>

--- a/writing/draft-development.html
+++ b/writing/draft-development.html
@@ -119,6 +119,13 @@
       </div>
     </section>
   </div>
+  <script>
+    window.activityOutcomes = [
+      'Follow a model philosophy paper from thesis through conclusion with annotated steps.',
+      'Customize paragraph templates, revision moves, and work plans for your own project.',
+      'Export explanations, timelines, and sources to support sustained drafting.'
+    ];
+  </script>
   <script src="draft-development.js"></script>
   <script src="../vendor/jspdf.umd.min.js"></script>
   <script src="../explain.js"></script>

--- a/writing/index.html
+++ b/writing/index.html
@@ -26,6 +26,13 @@
       <button onclick="location.href='ai-evaluation.html'">Bullshit Detector</button>
     </div>
   </div>
+  <script>
+    window.activityOutcomes = [
+      'Navigate the full writing workflow from brainstorming to peer feedback.',
+      'Select the right mini-tool for thesis, outlining, drafting, and revision needs.',
+      'Track links to explanations and rubrics that scaffold stronger philosophy papers.'
+    ];
+  </script>
   <script src="../explain.js"></script>
   <script src="../keyterms-sidebar.js"></script>
   <script src="../page-header.js"></script>

--- a/writing/outline-worksheet.html
+++ b/writing/outline-worksheet.html
@@ -48,6 +48,13 @@
       <button id="export-outline-pdf">Export Outline (PDF)</button>
     </div>
   </div>
+  <script>
+    window.activityOutcomes = [
+      'Draft a thesis, topic sentences, and supporting details for each paragraph.',
+      'Iteratively expand or duplicate sections to match assignment length and focus.',
+      'Export a polished outline with explanatory notes and citation reminders.'
+    ];
+  </script>
   <script src="outline-worksheet.js"></script>
   <script src="../vendor/jspdf.umd.min.js"></script>
   <script src="../explain.js"></script>

--- a/writing/outlining.html
+++ b/writing/outlining.html
@@ -71,6 +71,13 @@
     <button id="outline-btn">Open Outline Worksheet</button>
     <button id="open-draft-dev">Open Draft Development</button>
   </div>
+  <script>
+    window.activityOutcomes = [
+      'Organize claims, evidence, and objections into a thesis-driven outline.',
+      'Experiment with structure by dragging building blocks into argumentative order.',
+      'Annotate sections with explanations and sources that preview body paragraphs.'
+    ];
+  </script>
   <script src="../utils.js"></script>
   <script src="outlining.js"></script>
   <script src="../explain.js"></script>

--- a/writing/peer-review.html
+++ b/writing/peer-review.html
@@ -201,6 +201,13 @@
       <button id="print-review">Print Review</button>
     </section>
   </div>
+  <script>
+    window.activityOutcomes = [
+      'Model constructive philosophy peer review using annotated sample drafts.',
+      'Apply a rubric that weighs thesis clarity, structure, evidence, and prose.',
+      'Record evidence-based feedback and export it for your partner or instructor.'
+    ];
+  </script>
   <script src="peer-review.js"></script>
   <script src="../explain.js"></script>
   <script src="../keyterms-sidebar.js"></script>

--- a/writing/thesis-evaluation.html
+++ b/writing/thesis-evaluation.html
@@ -57,6 +57,13 @@
       <button id="reset-thesis">Reset</button>
     </div>
   </div>
+  <script>
+    window.activityOutcomes = [
+      'Diagnose strengths and weaknesses in sample and self-written thesis statements.',
+      'Iterate on revisions using targeted prompts about clarity, stakes, and argumentative focus.',
+      'Preserve feedback, explanations, and citations for inclusion in full drafts.'
+    ];
+  </script>
   <script src="thesis-evaluation.js"></script>
   <script src="../vendor/docx.umd.min.js"></script>
   <script src="../explain.js"></script>

--- a/writing/writing.html
+++ b/writing/writing.html
@@ -115,6 +115,13 @@
     </div>
   </div>
 
+  <script>
+    window.activityOutcomes = [
+      'Practice every stage of philosophy writing from citation fixes to revision.',
+      'Compare your responses to scaffolded exemplars with explanations and sources.',
+      'Export personal notes and insights to carry into longer assignments.'
+    ];
+  </script>
   <script src="writing.js"></script>
   <script src="../vendor/jspdf.umd.min.js"></script>
   <script src="../explain.js"></script>


### PR DESCRIPTION
## Summary
- render learning outcomes from `window.activityOutcomes` using a shared helper in `page-header.js`
- seed outcomes arrays for each activity page, ensuring the new section appears beneath every main heading
- add a visible title on the Jeopardy hub so the learning outcomes attach to the activity header

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e5a7419864832284afeafab381fbba