### PR TITLE
Add chapters 2-8 question sets and enhance practice modes

### DIFF
--- a/critical-thinking/chapters/ch02.json
+++ b/critical-thinking/chapters/ch02.json
@@ -1,0 +1,25 @@
+[
+  {
+    "id":"ct.ch02.types.001","course":"critical-thinking","chapter":2,"section":"Deduction & Induction","topic":"Type ID",
+    "type":"mc","stem":"“If the database is compromised, then credentials must be reset. The database is compromised; so credentials must be reset.”",
+    "options":["Inductive","Deductive"],
+    "key":1,
+    "explanation":"This aims for necessity via modus ponens, a deductive form.",
+    "source":"Bassham 7e, ch.2","difficulty":"easy"
+  },
+  {
+    "id":"ct.ch02.strength.002","course":"critical-thinking","chapter":2,"section":"Validity & Strength","topic":"Strength vs validity",
+    "type":"mc","stem":"An inductive argument is strong when ____.",
+    "options":["it is impossible for true premises to make the conclusion false","true premises make the conclusion probably true","the conclusion is analytic","the conclusion follows by contradiction"],
+    "key":1,
+    "explanation":"Inductive strength concerns probability, not necessity.",
+    "source":"Bassham 7e, ch.2","difficulty":"easy"
+  },
+  {
+    "id":"ct.ch02.cogency.003","course":"critical-thinking","chapter":2,"section":"Soundness & Cogency","topic":"Cogency",
+    "type":"flash","stem":"Define: cogent argument.",
+    "options":null,"key":null,
+    "explanation":"A strong inductive argument with true premises.",
+    "source":"Bassham 7e, ch.2","difficulty":"easy"
+  }
+]

--- a/critical-thinking/chapters/ch03.json
+++ b/critical-thinking/chapters/ch03.json
@@ -1,0 +1,25 @@
+[
+  {
+    "id":"ct.ch03.validity.001","course":"critical-thinking","chapter":3,"section":"Validity & Soundness","topic":"Validity",
+    "type":"mc","stem":"Validity concerns ____.",
+    "options":["truth of the premises","truth of the conclusion","the form: impossible for true premises and false conclusion","statistical representativeness"],
+    "key":2,
+    "explanation":"Validity is a property of form: true premises cannot yield a false conclusion.",
+    "source":"Bassham 7e, ch.3","difficulty":"easy"
+  },
+  {
+    "id":"ct.ch03.soundness.002","course":"critical-thinking","chapter":3,"section":"Validity & Soundness","topic":"Soundness",
+    "type":"flash","stem":"Define: sound argument.",
+    "options":null,"key":null,
+    "explanation":"A valid deductive argument with true premises.",
+    "source":"Bassham 7e, ch.3","difficulty":"easy"
+  },
+  {
+    "id":"ct.ch03.form.003","course":"critical-thinking","chapter":3,"section":"Argument Forms","topic":"Modus tollens",
+    "type":"reconstruction","stem":"Complete: If P then Q; not Q; therefore ____.",
+    "options":["P","not P","Q","P or Q"],
+    "key":1,
+    "explanation":"Modus tollens: from ¬Q and (P→Q), infer ¬P.",
+    "source":"Bassham 7e, ch.3","difficulty":"easy"
+  }
+]

--- a/critical-thinking/chapters/ch04.json
+++ b/critical-thinking/chapters/ch04.json
@@ -1,0 +1,30 @@
+[
+  {
+    "id":"ct.ch04.defs.001","course":"critical-thinking","chapter":4,"section":"Lexical/Stipulative/Precising","topic":"Precising",
+    "type":"mc","stem":"Which is a precising definition?",
+    "options":[
+      "A bachelor is an unmarried adult male.",
+      "For campus safety policy, ‘vehicle’ includes scooters and e‑bikes.",
+      "‘Zog’ means a post violating policy.",
+      "‘Atom’ means indivisible particle (ancient)."
+    ],
+    "key":1,
+    "explanation":"Precising narrows a vague term for a specific context (e.g., policy).",
+    "source":"Bassham 7e, ch.4","difficulty":"easy"
+  },
+  {
+    "id":"ct.ch04.persuasive.002","course":"critical-thinking","chapter":4,"section":"Persuasive","topic":"Persuasive def.",
+    "type":"mc","stem":"“Abortion is baby‑murder.” This is best classified as ____.",
+    "options":["lexical","stipulative","precising","persuasive"],
+    "key":3,
+    "explanation":"Loaded language used to sway attitudes rather than neutrally report meaning.",
+    "source":"Bassham 7e, ch.4","difficulty":"easy"
+  },
+  {
+    "id":"ct.ch04.stipulative.003","course":"critical-thinking","chapter":4,"section":"Lexical/Stipulative/Precising","topic":"Stipulative",
+    "type":"flash","stem":"Define: stipulative definition.",
+    "options":null,"key":null,
+    "explanation":"Assigns a new meaning by fiat for convenience in a context.",
+    "source":"Bassham 7e, ch.4","difficulty":"easy"
+  }
+]

--- a/critical-thinking/chapters/ch05.json
+++ b/critical-thinking/chapters/ch05.json
@@ -1,0 +1,25 @@
+[
+  {
+    "id":"ct.ch05.adhominem.001","course":"critical-thinking","chapter":5,"section":"Fallacies of Relevance","topic":"Ad hominem (abusive)",
+    "type":"mc","stem":"Which best illustrates ad hominem (abusive)?",
+    "options":["He’s wrong because he profits from it.","Don’t listen; she’s an idiot.","We need more data before concluding.","This confuses correlation with causation."],
+    "key":1,
+    "explanation":"Abusive ad hominem attacks the person’s character rather than the claim.",
+    "source":"Bassham 7e, ch.5","difficulty":"easy"
+  },
+  {
+    "id":"ct.ch05.straw.002","course":"critical-thinking","chapter":5,"section":"Fallacies of Relevance","topic":"Straw person",
+    "type":"mc","stem":"Straw person involves ____.",
+    "options":["attacking a weaker misrepresentation of an opponent’s view","appeal to unqualified authority","equivocating on a key term","citing a false dilemma"],
+    "key":0,
+    "explanation":"Distorts the target to an easier‑to‑refute version.",
+    "source":"Bassham 7e, ch.5","difficulty":"easy"
+  },
+  {
+    "id":"ct.ch05.redherring.003","course":"critical-thinking","chapter":5,"section":"Fallacies of Relevance","topic":"Red herring",
+    "type":"flash","stem":"Define: red herring.",
+    "options":null,"key":null,
+    "explanation":"Introducing an irrelevant issue to deflect from the point at hand.",
+    "source":"Bassham 7e, ch.5","difficulty":"easy"
+  }
+]

--- a/critical-thinking/chapters/ch06.json
+++ b/critical-thinking/chapters/ch06.json
@@ -1,0 +1,25 @@
+[
+  {
+    "id":"ct.ch06.hasty.001","course":"critical-thinking","chapter":6,"section":"Hasty Generalization","topic":"Sample size",
+    "type":"mc","stem":"A hasty generalization typically fails because ____.",
+    "options":["sample is too small or unrepresentative","premises are inconsistent","argument begs the question","terms are equivocal"],
+    "key":0,
+    "explanation":"Inductive generalization needs adequate, representative sampling.",
+    "source":"Bassham 7e, ch.6","difficulty":"easy"
+  },
+  {
+    "id":"ct.ch06.posthoc.002","course":"critical-thinking","chapter":6,"section":"Post Hoc","topic":"Causal",
+    "type":"mc","stem":"Post hoc ergo propter hoc mistakes ____.",
+    "options":["temporal order for causal connection","necessity for sufficiency","probability for certainty","legality for morality"],
+    "key":0,
+    "explanation":"That B followed A doesn’t show A caused B.",
+    "source":"Bassham 7e, ch.6","difficulty":"easy"
+  },
+  {
+    "id":"ct.ch06.weakanalogy.003","course":"critical-thinking","chapter":6,"section":"Weak Induction","topic":"Weak analogy",
+    "type":"flash","stem":"Define: weak analogy.",
+    "options":null,"key":null,
+    "explanation":"Drawing a conclusion from similarities that are too few or irrelevant to the property inferred.",
+    "source":"Bassham 7e, ch.6","difficulty":"easy"
+  }
+]

--- a/critical-thinking/chapters/ch07.json
+++ b/critical-thinking/chapters/ch07.json
@@ -1,0 +1,25 @@
+[
+  {
+    "id":"ct.ch07.equivocation.001","course":"critical-thinking","chapter":7,"section":"Equivocation","topic":"Ambiguity",
+    "type":"mc","stem":"Equivocation involves ____.",
+    "options":["changing the meaning of a key term mid‑argument","attacking the person","appeal to force","two wrongs make a right"],
+    "key":0,
+    "explanation":"The argument trades on a term used in two different senses.",
+    "source":"Bassham 7e, ch.7","difficulty":"easy"
+  },
+  {
+    "id":"ct.ch07.amphiboly.002","course":"critical-thinking","chapter":7,"section":"Amphiboly","topic":"Syntax",
+    "type":"mc","stem":"Amphiboly arises from ____.",
+    "options":["semantic ambiguity in a word","syntactic ambiguity in a sentence","statistical noise","category mistake"],
+    "key":1,
+    "explanation":"The structure/grammar creates multiple readings.",
+    "source":"Bassham 7e, ch.7","difficulty":"easy"
+  },
+  {
+    "id":"ct.ch07.composition.003","course":"critical-thinking","chapter":7,"section":"Ambiguity","topic":"Composition",
+    "type":"flash","stem":"Define: fallacy of composition.",
+    "options":null,"key":null,
+    "explanation":"Inferring that the whole has the properties of its parts.",
+    "source":"Bassham 7e, ch.7","difficulty":"easy"
+  }
+]

--- a/critical-thinking/chapters/ch08.json
+++ b/critical-thinking/chapters/ch08.json
@@ -1,0 +1,25 @@
+[
+  {
+    "id":"ct.ch08.dependent.001","course":"critical-thinking","chapter":8,"section":"Dependent vs Independent","topic":"Linked premises",
+    "type":"mc","stem":"P1 and P2 each give weak support alone but strong support together for C. They are ____ reasons.",
+    "options":["independent","coincidental","linked (dependent)","irrelevant"],
+    "key":2,
+    "explanation":"Linked (dependent) premises function jointly to support the conclusion.",
+    "source":"Bassham 7e, ch.8","difficulty":"easy"
+  },
+  {
+    "id":"ct.ch08.diagram.002","course":"critical-thinking","chapter":8,"section":"Argument Structure","topic":"Structure ID",
+    "type":"mc","stem":"Which best signals an independent reason?",
+    "options":["‘Together, these facts show that…’","‘Separately, either of the following supports…’","‘Only if both…’","‘Taken jointly…’"],
+    "key":1,
+    "explanation":"Language like ‘either’ or ‘separately’ suggests independent support.",
+    "source":"Bassham 7e, ch.8","difficulty":"easy"
+  },
+  {
+    "id":"ct.ch08.diagram.003","course":"critical-thinking","chapter":8,"section":"Argument Structure","topic":"Support",
+    "type":"flash","stem":"Define: independent vs linked support (one sentence).",
+    "options":null,"key":null,
+    "explanation":"Independent: premises each support C on their own; linked: premises must be combined to support C.",
+    "source":"Bassham 7e, ch.8","difficulty":"easy"
+  }
+]

--- a/critical-thinking/practice.html
+++ b/critical-thinking/practice.html
@@ -1,9 +1,8 @@
 <!doctype html>
 <html lang="en">
 <head>
-<meta charset="utf-8" />
-<meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Critical Thinking — Practice</title>
+<meta charset="utf-8" /><meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Critical Thinking — Practice / Exam / Cram</title>
 <style>
   body{font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;margin:0;background:#fafafa;color:#111}
   header{position:sticky;top:0;background:#fff;border-bottom:1px solid #eee;padding:12px 16px;display:flex;gap:12px;align-items:center;z-index:1}
@@ -22,46 +21,82 @@
   .toolbar button{border:1px solid #ddd;background:#fff;border-radius:6px;padding:8px 10px;cursor:pointer}
   .row{display:flex;justify-content:space-between;align-items:center;gap:12px}
   .hidden{display:none}
+  .timer{font-variant-numeric:tabular-nums}
 </style>
 </head>
 <body>
 <header>
   <h1>Critical Thinking</h1>
   <div class="controls">
-    <label>Chapter:
-      <select id="chapSel"><option value="">All</option></select>
+    <label>Chapter: <select id="chapSel"><option value="">All</option></select></label>
+    <label>Mode:
+      <select id="modeSel">
+        <option value="practice">Practice</option>
+        <option value="exam">Exam</option>
+        <option value="cram">Cram</option>
+      </select>
     </label>
-    <button id="startBtn">Start Practice</button>
+    <button id="startBtn">Start</button>
+    <span id="timer" class="timer muted small"></span>
   </div>
 </header>
 <main>
   <div id="intro" class="card">
-    <strong>Practice mode</strong>
-    <p class="muted small">Filter by chapter and practice. Explanations show after you answer.</p>
+    <strong>Practice / Exam / Cram</strong>
+    <p class="muted small">Practice shows explanations after each item. Exam hides explanations until you finish (default 30 Q / 35 min). Cram repeats missed items until you get them right once.</p>
   </div>
   <div id="stage" class="hidden"></div>
+  <div id="review" class="hidden"></div>
 </main>
 <script>
 const CT = {
-  items: [], chapters: [], state: {chapter:null, queue:[], index:0, score:0, wrong:[]},
+  items: [], chapters: [],
+  state:{mode:'practice', chapter:null, queue:[], index:0, score:0, wrong:[], startTs:0, timer:null, exam:{q:30, secs:35*60}},
   async init(){
     const idx = await fetch("./index.json").then(r=>r.json()).catch(()=>({chapters:[]}));
     this.chapters = (idx.chapters||[]).map(c=>c.num).sort((a,b)=>a-b);
-    const sel = document.getElementById('chapSel');
-    sel.innerHTML = '<option value="">All</option>'+this.chapters.map(n=>`<option>${n}</option>`).join('');
-    sel.onchange = ()=>{ this.state.chapter = sel.value?parseInt(sel.value,10):null; };
-    const toLoad = this.chapters.length?this.chapters:[1];
+    const ch = document.getElementById('chapSel');
+    ch.innerHTML = '<option value="">All</option>'+this.chapters.map(n=>`<option>${n}</option>`).join('');
+    ch.onchange = ()=>{ this.state.chapter = ch.value?parseInt(ch.value,10):null; };
+    document.getElementById('modeSel').onchange = (e)=>{ this.state.mode = e.target.value; };
+    document.getElementById('startBtn').onclick = ()=> this.start();
+    const toLoad = this.chapters.length?this.chapters:[1,2,3,4,5,6,7,8];
     const packs = await Promise.all(toLoad.map(n=>fetch(`./chapters/ch${String(n).padStart(2,'0')}.json`).then(r=>r.json()).catch(()=>[])));
     this.items = packs.flat();
-    document.getElementById('startBtn').onclick = ()=> this.start();
   },
   start(){
     const pool = this.items.filter(it=>!this.state.chapter || it.chapter===this.state.chapter);
-    if(pool.length===0){ alert('No items for the selected chapter yet.'); return; }
-    this.state.queue = this.shuffle(pool); this.state.index = 0; this.state.score = 0; this.state.wrong = [];
+    if(pool.length===0){ alert('No items for the selected chapter.'); return; }
+    if(this.state.mode==='exam'){
+      const qs = Math.min(this.state.exam.q, pool.length);
+      this.state.queue = CT.shuffle(pool).slice(0, qs);
+      this.state.score = 0; this.state.wrong = []; this.state.index=0; this.state.startTs=Date.now(); this.tick();
+    } else if(this.state.mode==='cram'){
+      const batch = Math.min(10, pool.length);
+      this.state.queue = CT.shuffle(pool).slice(0, batch);
+      this.state.score = 0; this.state.wrong = []; this.state.index=0; document.getElementById('timer').textContent='';
+      clearInterval(this.state.timer);
+    } else {
+      this.state.queue = CT.shuffle(pool);
+      this.state.score = 0; this.state.wrong = []; this.state.index=0; document.getElementById('timer').textContent='';
+      clearInterval(this.state.timer);
+    }
     document.getElementById('intro').classList.add('hidden');
+    document.getElementById('review').classList.add('hidden');
     document.getElementById('stage').classList.remove('hidden');
     this.render();
+  },
+  tick(){
+    clearInterval(this.state.timer);
+    if(this.state.mode!=='exam'){ document.getElementById('timer').textContent=''; return; }
+    const end = this.state.startTs + this.state.exam.secs*1000;
+    const update = ()=>{
+      const left = Math.max(0, Math.floor((end - Date.now())/1000));
+      const m = String(Math.floor(left/60)).padStart(2,'0'); const s = String(left%60).padStart(2,'0');
+      document.getElementById('timer').textContent = `⏱ ${m}:${s}`;
+      if(left<=0){ clearInterval(this.state.timer); CT.finishExam(); }
+    };
+    update(); this.state.timer = setInterval(update, 250);
   },
   render(){
     const it = this.state.queue[this.state.index]; if(!it){ return this.finish(); }
@@ -86,24 +121,44 @@ const CT = {
     if(it.type==='flash'){
       return `<div class="muted small">Flashcard</div>
         <div style="margin-top:8px"><em>Tap to reveal</em></div>
-        <div class="explanation hidden" id="exp"><div>${it.explanation||''}</div></div>
-        <div class="toolbar" style="margin-top:8px"><button onclick="document.getElementById('exp').classList.remove('hidden')">Reveal</button></div>`;
+        <div class="explanation ${this.state.mode==='exam'?'hidden':''}" id="exp"><div>${it.explanation||''}</div></div>
+        ${this.state.mode==='exam'?'':`<div class="toolbar" style="margin-top:8px"><button onclick="document.getElementById('exp').classList.remove('hidden')">Reveal</button></div>`}`;
     }
     const opts = (it.options||[]).map((opt,i)=>`<button onclick="CT.choose(${i})">${opt}</button>`).join('');
-    return `<div class="options">${opts}</div><div id="exp" class="explanation hidden"><div>${it.explanation||''}</div></div>`;
+    return `<div class="options">${opts}</div>
+      <div id="exp" class="explanation ${this.state.mode==='exam'?'hidden':''}"><div>${it.explanation||''}</div></div>`;
   },
   choose(i){
     const it = this.state.queue[this.state.index];
     const btns = Array.from(document.querySelectorAll('.options button'));
     btns.forEach((b,idx)=>{
       if(idx===it.key){ b.classList.add('correct'); }
-      if(idx===i && i!==it.key){ b.classList.add('incorrect'); this.state.wrong.push(it); }
+      if(idx===i && i!==it.key){ b.classList.add('incorrect'); if(this.state.mode==='cram'){ this.state.queue.push(it); } this.state.wrong.push(it); }
       b.disabled=true;
     });
-    document.getElementById('exp').classList.remove('hidden');
+    if(this.state.mode!=='exam'){ document.getElementById('exp').classList.remove('hidden'); }
     if(i===it.key) this.state.score++;
   },
-  finish(){ document.getElementById('stage').innerHTML = `<div class="card"><strong>Done.</strong> Score: ${this.state.score}/${this.state.queue.length}</div>`; },
+  finish(){
+    if(this.state.mode==='exam'){ return this.finishExam(); }
+    document.getElementById('stage').innerHTML = `<div class="card"><strong>Done.</strong> Score: ${this.state.score}/${this.state.queue.length}</div>`;
+  },
+  finishExam(){
+    const total = this.state.queue.length, right = this.state.score;
+    const pct = Math.round(100*right/Math.max(1,total));
+    const review = document.getElementById('review');
+    review.classList.remove('hidden');
+    review.innerHTML = `
+      <div class="card"><strong>Exam complete.</strong> Score: ${right}/${total} (${pct}%) <div class="muted small">Explanations below.</div></div>
+      ${this.state.queue.map(w=>`
+        <div class="card">
+          <div><strong>${w.stem}</strong> <span class="badge">Ch. ${w.chapter}${w.section?(' • '+w.section):''}</span></div>
+          <div class="explanation"><div>${w.explanation||''}</div><div class="muted small">Source: ${w.source||'—'}</div></div>
+        </div>`).join('')}
+    `;
+    document.getElementById('stage').classList.add('hidden');
+    document.getElementById('timer').textContent=''; clearInterval(this.state.timer);
+  },
   shuffle(a){ const x=a.slice(); for(let i=x.length-1;i>0;i--){ const j=Math.floor(Math.random()*(i+1)); [x[i],x[j]]=[x[j],x[i]]; } return x; }
 };
 window.addEventListener('DOMContentLoaded', ()=>CT.init());


### PR DESCRIPTION
## Summary
- add question banks for chapters 2 through 8 covering key critical thinking concepts
- extend practice page with practice, exam, and cram modes including timers and review states

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5f800a388832290f38660f481d873